### PR TITLE
Implemented persistency of plugin index for plugins repository in filesystem

### DIFF
--- a/api/routes.cpp
+++ b/api/routes.cpp
@@ -36,4 +36,5 @@ void installRoutes(HttpServer& http_server)
     http_server.get("/plugins/:pluginName", [&](struct http_request &request) -> struct http_response {
         return plugins_api.downloadPlugin(request);
     });
+    plugins_repository.restore(".");
 }

--- a/api/routes.cpp
+++ b/api/routes.cpp
@@ -21,8 +21,8 @@
 #include <api/plugins_api.h>
 
 
-static PluginIndex plugin_index;
 static Filesystem filesystem;
+static PluginIndex plugin_index;
 static PluginsRepositoryInFilesystem plugins_repository(&filesystem, &plugin_index, ".");
 static PluginsService plugins_service(&plugins_repository);
 static PluginsApi plugins_api(&plugins_service);

--- a/infrastructure/http_client.cpp
+++ b/infrastructure/http_client.cpp
@@ -17,6 +17,7 @@
  */
 #include <infrastructure/http_client.h>
 
+
 static void eventHandler(struct mg_connection *connection, int event, void *data);
 
 

--- a/infrastructure/plugin_index.cpp
+++ b/infrastructure/plugin_index.cpp
@@ -60,7 +60,7 @@ string PluginIndex::serialize()
 }
 
 
-void PluginIndex::load(std::string serialized)
+void PluginIndex::restore(std::string serialized)
 {
     auto json = json::parse(serialized);
 

--- a/infrastructure/plugin_index.cpp
+++ b/infrastructure/plugin_index.cpp
@@ -58,3 +58,13 @@ string PluginIndex::serialize()
 
     return json_index.dump();
 }
+
+
+void PluginIndex::load(std::string serialized)
+{
+    auto json = json::parse(serialized);
+
+    for (auto& element: json.items()) {
+        this->indexPlugin(element.key(), element.value());
+    }
+}

--- a/infrastructure/plugin_index.h
+++ b/infrastructure/plugin_index.h
@@ -39,7 +39,7 @@ public:
 
     virtual std::string serialize();
 
-    virtual void load(std::string serialized);
+    virtual void restore(std::string serialized);
 
 private:
     Filesystem *filesystem;

--- a/infrastructure/plugin_index.h
+++ b/infrastructure/plugin_index.h
@@ -39,6 +39,8 @@ public:
 
     virtual std::string serialize();
 
+    virtual void load(std::string serialized);
+
 private:
     Filesystem *filesystem;
     std::string directory;

--- a/infrastructure/plugins_repository_in_filesystem.cpp
+++ b/infrastructure/plugins_repository_in_filesystem.cpp
@@ -42,6 +42,7 @@ PluginsRepositoryInFilesystem::PluginsRepositoryInFilesystem(Filesystem *filesys
     this->filesystem = filesystem;
     this->directory = directory;
     this->index = index;
+    this->index_file = this->directory + "/index.json";
 }
 
 
@@ -53,6 +54,7 @@ void PluginsRepositoryInFilesystem::add(Plugin &plugin)
     this->savePayload(plugin.metadata.name, plugin_directory, plugin.payload);
     this->saveMetadata(plugin.metadata.name, plugin_directory, plugin.metadata);
     this->index->indexPlugin(plugin.metadata.name, plugin_directory);
+    this->filesystem->writeFile(this->index_file, this->index->serialize());
 }
 
 
@@ -113,4 +115,12 @@ list<Plugin> PluginsRepositoryInFilesystem::allPlugins()
 {
     list<Plugin> plugins;
     return plugins;
+}
+
+
+void PluginsRepositoryInFilesystem::restore(string directory)
+{
+    this->directory = directory;
+    this->index_file = this->directory + "/index.json";
+    this->index->restore(this->filesystem->readFile(this->index_file));
 }

--- a/infrastructure/plugins_repository_in_filesystem.h
+++ b/infrastructure/plugins_repository_in_filesystem.h
@@ -34,8 +34,11 @@ public:
 
     virtual std::list<Plugin> allPlugins();
 
+    void restore(std::string directory);
+
 private:
     std::string directory;
+    std::string index_file;
     Filesystem *filesystem;
     PluginIndex *index;
 

--- a/tests/unit/infrastructure/test_plugin_index.cpp
+++ b/tests/unit/infrastructure/test_plugin_index.cpp
@@ -71,4 +71,18 @@ describe("Plugins Repository in file system", []() {
         expect(plugin_index.find("cest").value()).toBe("user/cest/1.0");
         expect(plugin_index.find("fakeit").value()).toBe("user/fakeit/3.1");
     });
+
+    if("loads the index from serialized dump", []() {
+        PluginIndex plugin_index;
+        string serialized(
+        "{"
+            "\"cest\":\"user/cest/1.0\","
+            "\"fakeit\":\"user/fakeit/3.1\""
+        "}");
+
+        plugin_index.load(serialized);
+
+        expect(plugin_index.find("cest").value()).toBe("user/cest/1.0");
+        expect(plugin_index.find("fakeit").value()).toBe("user/fakeit/3.1");
+    });
 });

--- a/tests/unit/infrastructure/test_plugin_index.cpp
+++ b/tests/unit/infrastructure/test_plugin_index.cpp
@@ -80,7 +80,7 @@ describe("Plugins Repository in file system", []() {
             "\"fakeit\":\"user/fakeit/3.1\""
         "}");
 
-        plugin_index.load(serialized);
+        plugin_index.restore(serialized);
 
         expect(plugin_index.find("cest").value()).toBe("user/cest/1.0");
         expect(plugin_index.find("fakeit").value()).toBe("user/fakeit/3.1");

--- a/tests/unit/infrastructure/test_plugins_repository_in_filesystem.cpp
+++ b/tests/unit/infrastructure/test_plugins_repository_in_filesystem.cpp
@@ -28,14 +28,6 @@ using namespace fakeit;
 
 
 describe("Plugins Repository in file system", []() {
-    
-
-    beforeEach([&]() {
-    });
-
-    afterEach([&]() {
-    });
-
     it("stores and indexes one plugin", [&]() {
         Mock<Filesystem> mock_filesystem;
         PluginIndex plugin_index;

--- a/tests/unit/infrastructure/test_plugins_repository_in_filesystem.cpp
+++ b/tests/unit/infrastructure/test_plugins_repository_in_filesystem.cpp
@@ -45,6 +45,10 @@ describe("Plugins Repository in file system", []() {
             "./user/cest/1.0/cest.json", 
             "{\"name\":\"cest\",\"user_name\":\"user\",\"version\":\"1.0\"}"
         ));
+        Verify(Method(mock_filesystem, writeFile).Using(
+            "./index.json",
+            "{\"cest\":\"./user/cest/1.0\"}"
+        ));
     });
 
     it("doesn't find a non existent plugin", []() {
@@ -76,6 +80,27 @@ describe("Plugins Repository in file system", []() {
         } catch(std::exception e) {
             cout << e.what() << endl;
         }
+
+        expect(plugin.value().metadata.name).toBe("cest");
+        expect(plugin.value().metadata.version).toBe("1.0");
+        expect(plugin.value().metadata.user_name).toBe("user");
+        expect(plugin.value().payload).toBe("cGx1Z2luIHBheWxvYWQ=");
+    });
+
+    it("finds an indexed plugin after index was restored from filesystem", [&]() {
+        Mock<Filesystem> mock_filesystem;
+        PluginIndex plugin_index;
+        PluginsRepositoryInFilesystem repository(&mock_filesystem.get(), &plugin_index, ".");
+        Optional<Plugin> plugin;
+        Optional<string> directory;
+
+        When(Method(mock_filesystem, readFile))
+                .Return("{\"cest\":\"./user/cest/1.0\"}")
+                .Return("{\"name\":\"cest\",\"user_name\":\"user\",\"version\":\"1.0\"}")
+                .Return("plugin payload");
+
+        repository.restore(".");
+        plugin = repository.find("cest");
 
         expect(plugin.value().metadata.name).toBe("cest");
         expect(plugin.value().metadata.version).toBe("1.0");


### PR DESCRIPTION
This pull requests adds persistency to the plugin index in a file `index.json`. The index will be restored when the application is re-launched. The index file is updated every time a new plugin is published.