### PR TITLE
Catch unhandled exceptions thrown by http server callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Mkfile.old
 dkms.conf
 build/
 cmake-build-debug/
+cmake-build-build/
 .idea/
 .vscode/
 CMakeLists.txt

--- a/infrastructure/http_server.cpp
+++ b/infrastructure/http_server.cpp
@@ -173,7 +173,11 @@ void HttpServer::serveRequest(struct mg_connection *connection, struct http_mess
     HttpRequest request;
     ServerCallback callback = this->parseRequest(message, request);
 
-    response = callback(request);
+    try {
+        response = callback(request);
+    } catch (exception &e) {
+        response = HttpResponse(500, "");
+    }
 
     mg_send_head(connection, response.status_code, response.body.size(), "");
     mg_printf(connection, "%s", response.body.c_str());

--- a/tests/unit/infrastructure/test_http_server.cpp
+++ b/tests/unit/infrastructure/test_http_server.cpp
@@ -48,6 +48,11 @@ static HttpResponse putPlugin(HttpRequest request)
     return put_plugin_response;
 }
 
+static HttpResponse throwsException(HttpRequest request)
+{
+    throw std::exception();
+}
+
 
 describe("HTTP server based on Cesanta Mongoose", []() {
     it("starts and stops an HTTP server", [&]() {
@@ -143,6 +148,23 @@ describe("HTTP server based on Cesanta Mongoose", []() {
 
         expect(response.status_code).toBe(200);
         expect(response.body).toBe("hello");
+
+        server.stop();
+    });
+
+    it("returns error 500 when callback throws an exception", [&]() {
+        HttpServer server;
+        HttpClient client;
+        HttpResponse response;
+
+        get_plugins_response.body = "hello";
+        get_plugins_response.status_code = 200;
+        server.get("/plugins", throwsException);
+        server.startAsync("127.0.0.1", 8000);
+
+        response = client.get("http://127.0.0.1:8000/plugins", HttpRequest(""));
+
+        expect(response.status_code).toBe(500);
 
         server.stop();
     });


### PR DESCRIPTION
This pull request handles the exceptions thrown by the http server callbacks so that the server does not crash when some method fails.

Closes #20 