### PR TITLE
Allow downloading specific plugin version

### DIFF
--- a/cpm-hub/http/Endpoint.cpp
+++ b/cpm-hub/http/Endpoint.cpp
@@ -24,8 +24,8 @@ using namespace std;
 
 Endpoint::Endpoint(string path)
 {
-    parsePath(path);
     matching_string = "";
+    parsePath(path);
 }
 
 
@@ -54,7 +54,7 @@ void Endpoint::parsePath(string path)
     boost::split(tokens, path, boost::is_any_of("/"));
     for(auto&& token: tokens) {
         if (token.front() == ':') {
-            matching_string += "/([\\w-]+)";
+            matching_string += "/([\\w\\-0-9\\\\.]+)";
             this->parameter_names.push_back(token.substr(1));
         } else {
             matching_string += "/" + token;

--- a/cpm-hub/http/Endpoint.cpp
+++ b/cpm-hub/http/Endpoint.cpp
@@ -15,11 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <iostream>
-
 #include <boost/algorithm/string.hpp>
 #include <http/Endpoint.h>
-#include "HttpParameterMap.h"
+#include <http/HttpParameterMap.h>
 
 using namespace std;
 

--- a/cpm-hub/infrastructure/Filesystem.cpp
+++ b/cpm-hub/infrastructure/Filesystem.cpp
@@ -92,3 +92,9 @@ list<string> Filesystem::listDirectories(string path)
     }
     return directories;
 }
+
+
+bool Filesystem::directoryExists(string path)
+{
+    return boost::filesystem::exists(path) && boost::filesystem::is_directory(path);
+}

--- a/cpm-hub/infrastructure/Filesystem.cpp
+++ b/cpm-hub/infrastructure/Filesystem.cpp
@@ -23,7 +23,7 @@
 using namespace std;
 
 
-void Filesystem::writeFile(std::string file_name, std::string contents)
+void Filesystem::writeFile(string file_name, string contents)
 {
     ofstream file;
 
@@ -33,7 +33,7 @@ void Filesystem::writeFile(std::string file_name, std::string contents)
 }
 
 
-std::string Filesystem::readFile(std::string file_name)
+string Filesystem::readFile(string file_name)
 {
     ifstream file(file_name, ios::binary);
     ostringstream ostream;
@@ -44,24 +44,24 @@ std::string Filesystem::readFile(std::string file_name)
 }
 
 
-void Filesystem::createDirectory(std::string path)
+void Filesystem::createDirectory(string path)
 {
     boost::filesystem::create_directories(path);
 }
 
 
-bool Filesystem::fileExists(std::string path)
+bool Filesystem::fileExists(string path)
 {
     return boost::filesystem::exists(path);
 }
 
 
-void Filesystem::deleteFile(std::string file_name)
+void Filesystem::deleteFile(string file_name)
 {
     remove(file_name.c_str());
 }
 
-void Filesystem::changePermissions(std::string file_name, unsigned int mask)
+void Filesystem::changePermissions(string file_name, unsigned int mask)
 {
     using namespace boost::filesystem;
     perms boost_permissions(no_perms);
@@ -78,4 +78,17 @@ void Filesystem::changePermissions(std::string file_name, unsigned int mask)
     }
 
     permissions(path, boost_permissions);
+}
+
+
+list<string> Filesystem::listDirectories(string path)
+{
+    list<string> directories;
+
+    for(auto &entry: boost::filesystem::directory_iterator(path)) {
+        if (boost::filesystem::is_directory(entry)) {
+            directories.emplace_back(entry.path().c_str());
+        }
+    }
+    return directories;
 }

--- a/cpm-hub/infrastructure/Filesystem.h
+++ b/cpm-hub/infrastructure/Filesystem.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string>
+#include <list>
 
 #define FILESYSTEM_PERMISSION_READ  (1U)
 #define FILESYSTEM_PERMISSION_WRITE (2U)
@@ -30,6 +31,8 @@ public:
     virtual std::string readFile(std::string file_name);
 
     virtual void createDirectory(std::string path);
+
+    virtual std::list<std::string> listDirectories(std::string path);
 
     virtual bool fileExists(std::string file_name);
 

--- a/cpm-hub/infrastructure/Filesystem.h
+++ b/cpm-hub/infrastructure/Filesystem.h
@@ -36,6 +36,8 @@ public:
 
     virtual bool fileExists(std::string file_name);
 
+    virtual bool directoryExists(std::string path);
+
     virtual void deleteFile(std::string file_name);
 
     virtual void changePermissions(std::string file_name, unsigned int mask);

--- a/cpm-hub/management/http_routes.cpp
+++ b/cpm-hub/management/http_routes.cpp
@@ -29,6 +29,9 @@ void installServiceRoutes(HttpServer& http_server, PluginsApi *plugins_api)
     http_server.get("/plugins/:pluginName", [plugins_api](HttpRequest &request) -> HttpResponse {
         return plugins_api->downloadPlugin(request);
     });
+    http_server.get("/plugins/:pluginName/:pluginVersion", [plugins_api](HttpRequest &request) -> HttpResponse {
+        return plugins_api->downloadPlugin(request);
+    });
 }
 
 

--- a/cpm-hub/plugins/PluginIndex.cpp
+++ b/cpm-hub/plugins/PluginIndex.cpp
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <iostream>
+#include <boost/algorithm/string.hpp>
 #include <json/json.hpp>
 #include <plugins/PluginIndex.h>
 
@@ -23,15 +23,11 @@ using namespace std;
 using namespace nlohmann;
 
 
-void PluginIndex::indexPlugin(std::string name, std::string directory)
+void PluginIndex::indexPlugin(string name, string username, std::string directory)
 {
-    auto iter = this->plugins.find(name);
+    PluginIndexEntry index_entry = {username, directory};
 
-    if (iter != this->plugins.end()) {
-        iter->second = directory;
-    } else {
-        this->plugins.insert(make_pair(name, directory));
-    }
+    this->plugins[name] = index_entry;
 }
 
 
@@ -44,9 +40,15 @@ Optional<string> PluginIndex::find(string name)
         return directory;
     }
 
-    directory = iter->second;
+    directory = iter->second.directory;
 
     return directory;
+}
+
+
+Optional<std::string> PluginIndex::find(std::string name, std::string version)
+{
+    return Optional<std::string>();
 }
 
 
@@ -54,12 +56,14 @@ string PluginIndex::serialize()
 {
     json json_index;
     string plugin_name;
-    string directory;
+    PluginIndexEntry index_entry;
 
+    json_index["__version__"] = this->index_version;
     for (auto iter : this->plugins) {
         plugin_name = iter.first;
-        directory = iter.second;
-        json_index[plugin_name] = directory;
+        index_entry = iter.second;
+        json_index[plugin_name]["username"] = index_entry.username;
+        json_index[plugin_name]["directory"] = index_entry.directory;
     }
 
     return json_index.dump();
@@ -70,7 +74,25 @@ void PluginIndex::restore(std::string serialized)
 {
     auto json = json::parse(serialized);
 
+    if (!json.contains("__version__")) {
+        this->restoreFromVersion0(serialized);
+    }
+
     for (auto& element: json.items()) {
-        this->indexPlugin(element.key(), element.value());
+        this->indexPlugin(element.key(), element.value().at("username"), element.value().at("directory"));
+    }
+}
+
+
+void PluginIndex::restoreFromVersion0(std::string serialized)
+{
+    auto json = json::parse(serialized);
+
+    for (auto& element: json.items()) {
+        string directory = element.value();
+        vector<string> tokens;
+
+        boost::split(tokens, directory, boost::is_any_of("/"));
+        this->indexPlugin(element.key(), tokens.at(0), tokens.at(1));
     }
 }

--- a/cpm-hub/plugins/PluginIndex.cpp
+++ b/cpm-hub/plugins/PluginIndex.cpp
@@ -46,12 +46,6 @@ Optional<string> PluginIndex::find(string name)
 }
 
 
-Optional<std::string> PluginIndex::find(std::string name, std::string version)
-{
-    return Optional<std::string>();
-}
-
-
 string PluginIndex::serialize()
 {
     json json_index;
@@ -76,10 +70,13 @@ void PluginIndex::restore(std::string serialized)
 
     if (!json.contains("__version__")) {
         this->restoreFromVersion0(serialized);
+        return;
     }
 
     for (auto& element: json.items()) {
-        this->indexPlugin(element.key(), element.value().at("username"), element.value().at("directory"));
+        if (element.key() != "__version__") {
+            this->indexPlugin(element.key(), element.value().at("username"), element.value().at("directory"));
+        }
     }
 }
 
@@ -93,6 +90,6 @@ void PluginIndex::restoreFromVersion0(std::string serialized)
         vector<string> tokens;
 
         boost::split(tokens, directory, boost::is_any_of("/"));
-        this->indexPlugin(element.key(), tokens.at(0), tokens.at(1));
+        this->indexPlugin(element.key(), tokens.at(0), tokens.at(0)+"/"+tokens.at(1));
     }
 }

--- a/cpm-hub/plugins/PluginIndex.h
+++ b/cpm-hub/plugins/PluginIndex.h
@@ -26,23 +26,29 @@
 #include <plugins/PluginMetadata.h>
 
 
-struct plugin_index_entry {
-    PluginMetadata metadata;
+struct PluginIndexEntry {
+    std::string username;
+    std::string directory;
 };
 
 
 class PluginIndex {
 public:
-    virtual void indexPlugin(std::string name, std::string directory);
+    virtual void indexPlugin(std::string name, std::string username, std::string directory);
 
     virtual Optional<std::string> find(std::string name);
+
+    virtual Optional<std::string> find(std::string name, std::string version);
 
     virtual std::string serialize();
 
     virtual void restore(std::string serialized);
 
 private:
+    const std::string index_version = "1";
     Filesystem *filesystem;
     std::string directory;
-    std::map<std::string, std::string> plugins;
+    std::map<std::string, PluginIndexEntry> plugins;
+
+    void restoreFromVersion0(std::string serialized);
 };

--- a/cpm-hub/plugins/PluginIndex.h
+++ b/cpm-hub/plugins/PluginIndex.h
@@ -38,8 +38,6 @@ public:
 
     virtual Optional<std::string> find(std::string name);
 
-    virtual Optional<std::string> find(std::string name, std::string version);
-
     virtual std::string serialize();
 
     virtual void restore(std::string serialized);

--- a/cpm-hub/plugins/PluginsRepository.h
+++ b/cpm-hub/plugins/PluginsRepository.h
@@ -30,5 +30,7 @@ public:
 
     virtual Optional<Plugin> find(std::string name) = 0;
 
+    virtual Optional<Plugin> find(std::string name, std::string version) = 0;
+
     virtual std::list<Plugin>allPlugins() = 0;
 };

--- a/cpm-hub/plugins/PluginsRepositoryInFilesystem.cpp
+++ b/cpm-hub/plugins/PluginsRepositoryInFilesystem.cpp
@@ -90,7 +90,7 @@ void PluginsRepositoryInFilesystem::saveMetadata(const string& name, const strin
 }
 
 
-Optional<Plugin> PluginsRepositoryInFilesystem::find(string name)
+Optional<Plugin> PluginsRepositoryInFilesystem::find(std::string name)
 {
     Optional<Plugin> plugin;
     Optional<string> relative_directory;
@@ -139,4 +139,10 @@ void PluginsRepositoryInFilesystem::restore(string directory)
     if (this->filesystem->fileExists(this->index_file)) {
         this->index->restore(this->filesystem->readFile(this->index_file));
     }
+}
+
+
+Optional<Plugin> PluginsRepositoryInFilesystem::find(std::string name, std::string version)
+{
+    return Optional<Plugin>();
 }

--- a/cpm-hub/plugins/PluginsRepositoryInFilesystem.cpp
+++ b/cpm-hub/plugins/PluginsRepositoryInFilesystem.cpp
@@ -117,7 +117,25 @@ string PluginsRepositoryInFilesystem::latestVersionDirectory(string base_directo
 
 Optional<Plugin> PluginsRepositoryInFilesystem::find(std::string name, std::string version)
 {
-    return Optional<Plugin>();
+    Optional<Plugin> plugin;
+    Optional<string> base_directory;
+    string plugin_directory;
+
+    base_directory = this->index->find(name);
+    if (!base_directory.isPresent()) {
+        return plugin;
+    }
+
+    plugin_directory = this->directory + "/" + base_directory.value() + "/" + version;
+    if (!this->filesystem->directoryExists(plugin_directory)) {
+        return plugin;
+    }
+
+    PluginMetadata metadata = this->loadMetadata(name, plugin_directory);
+    string payload = this->loadPayload(name, directory);
+    plugin = Plugin(name, metadata.version, metadata.user_name, payload);
+
+    return plugin;
 }
 
 

--- a/cpm-hub/plugins/PluginsRepositoryInFilesystem.cpp
+++ b/cpm-hub/plugins/PluginsRepositoryInFilesystem.cpp
@@ -92,15 +92,17 @@ void PluginsRepositoryInFilesystem::saveMetadata(const string& name, const strin
 Optional<Plugin> PluginsRepositoryInFilesystem::find(std::string name)
 {
     Optional<Plugin> plugin;
-    Optional<string> base_directory;
+    Optional<string> index_directory;
+    string plugin_directory;
 
-    base_directory = this->index->find(name);
-    if (!base_directory.isPresent()) {
+    index_directory = this->index->find(name);
+    if (!index_directory.isPresent()) {
         return plugin;
     }
 
-    PluginMetadata metadata = this->loadMetadata(name, latestVersionDirectory(base_directory.value()));
-    string payload = this->loadPayload(name, directory);
+    plugin_directory = latestVersionDirectory(this->directory + "/" + index_directory.value());
+    PluginMetadata metadata = this->loadMetadata(name, plugin_directory);
+    string payload = this->loadPayload(name, plugin_directory);
     plugin = Plugin(name, metadata.version, metadata.user_name, payload);
 
     return plugin;
@@ -111,7 +113,7 @@ string PluginsRepositoryInFilesystem::latestVersionDirectory(string base_directo
 {
     list<string> versions = filesystem->listDirectories(base_directory);
     versions.sort();
-    return this->directory + "/" + base_directory + "/" + versions.back();
+    return versions.back();
 }
 
 
@@ -132,7 +134,7 @@ Optional<Plugin> PluginsRepositoryInFilesystem::find(std::string name, std::stri
     }
 
     PluginMetadata metadata = this->loadMetadata(name, plugin_directory);
-    string payload = this->loadPayload(name, directory);
+    string payload = this->loadPayload(name, plugin_directory);
     plugin = Plugin(name, metadata.version, metadata.user_name, payload);
 
     return plugin;

--- a/cpm-hub/plugins/PluginsRepositoryInFilesystem.h
+++ b/cpm-hub/plugins/PluginsRepositoryInFilesystem.h
@@ -34,6 +34,8 @@ public:
 
     virtual Optional<Plugin> find(std::string name);
 
+    virtual Optional<Plugin> find(std::string name, std::string version);
+
     virtual std::list<Plugin> allPlugins();
 
     void restore(std::string directory);

--- a/cpm-hub/plugins/PluginsRepositoryInFilesystem.h
+++ b/cpm-hub/plugins/PluginsRepositoryInFilesystem.h
@@ -53,4 +53,6 @@ private:
     std::string loadPayload(std::string name, std::string plugin_directory);
 
     PluginMetadata loadMetadata(const std::string& name, std::string plugin_directory);
+
+    std::string latestVersionDirectory(std::string base_directory);
 };

--- a/cpm-hub/plugins/PluginsRepositoryInMemory.cpp
+++ b/cpm-hub/plugins/PluginsRepositoryInMemory.cpp
@@ -49,3 +49,9 @@ std::list<Plugin> PluginsRepositoryInMemory::allPlugins()
 
     return stored_plugins;
 }
+
+
+Optional<Plugin> PluginsRepositoryInMemory::find(std::string name, std::string version)
+{
+    return Optional<Plugin>();
+}

--- a/cpm-hub/plugins/PluginsRepositoryInMemory.cpp
+++ b/cpm-hub/plugins/PluginsRepositoryInMemory.cpp
@@ -17,41 +17,73 @@
  */
 #include <plugins/PluginsRepositoryInMemory.h>
 
+using namespace std;
 
-void PluginsRepositoryInMemory::add(Plugin &plugin)
+
+static bool compareVersion(const Plugin& first, const Plugin& second)
 {
-    this->plugins.insert(std::make_pair(plugin.metadata.name, plugin));
+    return first.metadata.version < second.metadata.version;
 }
 
 
-Optional<Plugin> PluginsRepositoryInMemory::find(std::string name)
+void PluginsRepositoryInMemory::add(Plugin &plugin)
 {
-    auto iter = this->plugins.find(name);
+    if (!pluginExists(plugin)) {
+        this->plugins[plugin.metadata.name] = list<Plugin>();
+    }
+
+    this->plugins[plugin.metadata.name].push_back(plugin);
+    this->plugins[plugin.metadata.name].sort(compareVersion);
+}
+
+
+bool PluginsRepositoryInMemory::pluginExists(const Plugin &plugin) const
+{
+    return plugins.find(plugin.metadata.name) != plugins.end();
+}
+
+
+Optional<Plugin> PluginsRepositoryInMemory::find(string name)
+{
     Optional<Plugin> plugin;
 
-    if (iter == this->plugins.end()) {
+    if (!pluginExists(name)) {
         return plugin;
     }
 
-    plugin = iter->second;
+    plugin = this->plugins[name].back();
     
     return plugin;
 }
 
 
-std::list<Plugin> PluginsRepositoryInMemory::allPlugins()
+Optional<Plugin> PluginsRepositoryInMemory::find(string name, string version)
 {
-    std::list<Plugin> stored_plugins;
+    Optional<Plugin> plugin;
 
-    for (std::pair<std::string, Plugin> iter : this->plugins) {
-        stored_plugins.push_back(iter.second);
+    if (!pluginExists(name)) {
+        return plugin;
     }
 
-    return stored_plugins;
+    for (auto &plugin_version: this->plugins[name]) {
+        if (plugin_version.metadata.version == version) {
+            plugin = plugin_version;
+        }
+    }
+
+    return plugin;
 }
 
 
-Optional<Plugin> PluginsRepositoryInMemory::find(std::string name, std::string version)
+list<Plugin> PluginsRepositoryInMemory::allPlugins()
 {
-    return Optional<Plugin>();
+    list<Plugin> stored_plugins;
+
+    for (auto &plugin_map: this->plugins) {
+        for (auto &plugin: plugin_map.second) {
+            stored_plugins.push_back(plugin);
+        }
+    }
+
+    return stored_plugins;
 }

--- a/cpm-hub/plugins/PluginsRepositoryInMemory.h
+++ b/cpm-hub/plugins/PluginsRepositoryInMemory.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <map>
+#include <list>
 #include <string>
 #include <plugins/PluginsRepository.h>
 
@@ -33,5 +34,7 @@ public:
     virtual std::list<Plugin> allPlugins();
 
 private:
-    std::map<std::string, Plugin> plugins;
+    std::map<std::string, std::list<Plugin>> plugins;
+
+    bool pluginExists(const Plugin &plugin) const;
 };

--- a/cpm-hub/plugins/PluginsRepositoryInMemory.h
+++ b/cpm-hub/plugins/PluginsRepositoryInMemory.h
@@ -28,6 +28,8 @@ public:
 
     virtual Optional<Plugin> find(std::string name);
 
+    virtual Optional<Plugin> find(std::string name, std::string version);
+
     virtual std::list<Plugin> allPlugins();
 
 private:

--- a/cpm-hub/plugins/PluginsService.cpp
+++ b/cpm-hub/plugins/PluginsService.cpp
@@ -49,3 +49,9 @@ Optional<Plugin> PluginsService::find(std::string plugin_name)
 {
     return plugins_repository->find(plugin_name);
 }
+
+
+Optional<Plugin> PluginsService::find(std::string plugin_name, std::string version)
+{
+    return plugins_repository->find(plugin_name, version);
+}

--- a/cpm-hub/plugins/PluginsService.h
+++ b/cpm-hub/plugins/PluginsService.h
@@ -35,6 +35,8 @@ public:
     
     virtual Optional<Plugin> find(std::string plugin_name);
 
+    virtual Optional<Plugin> find(std::string name, std::string version);
+
 private:
     PluginsRepository *plugins_repository;
 };

--- a/cpm-hub/plugins/rest_api/PluginsApi.cpp
+++ b/cpm-hub/plugins/rest_api/PluginsApi.cpp
@@ -92,7 +92,13 @@ HttpResponse PluginsApi::downloadPlugin(HttpRequest &request)
 {
     Optional<Plugin> plugin;
 
-    plugin = plugins_service->find(request.parameters.get("pluginName"));
+    if (!request.parameters.has("pluginVersion")) {
+        plugin = plugins_service->find(request.parameters.get("pluginName"));
+    } else {
+        plugin = plugins_service->find(
+                request.parameters.get("pluginName"),
+                request.parameters.get("pluginVersion"));
+    }
     if (!plugin.isPresent()) {
         return HttpResponse(HttpStatus::NOT_FOUND, "");
     }

--- a/tests/integration/test_plugins.cpp
+++ b/tests/integration/test_plugins.cpp
@@ -120,4 +120,28 @@ describe("CPM Hub plugins management", []() {
         expect(response.status_code).toBe(HttpStatus::OK);
         expect(response.body).toBe("{\"payload\":\"ABCDEabcde\",\"plugin_name\":\"cest\",\"version\":\"1.0\"}");
     });
+
+    it("finds a plugin given version after it has been registered", [&]() {
+        HttpRequest publish_request("{"
+            "\"plugin_name\": \"cest\","
+            "\"version\": \"1.0\","
+            "\"payload\": \"ABCDEabcde\","
+            "\"username\": \"john_doe\","
+            "\"password\": \"12345\""
+        "}");
+        HttpRequest download_request;
+        HttpResponse response;
+        PluginsRepositoryInMemory repository;
+        PluginsService service(&repository);
+        PluginsApi api(&service);
+
+        api.publishPlugin(publish_request);
+
+        download_request.parameters.set("pluginName", "cest");
+        download_request.parameters.set("pluginVersion", "1.0");
+        response = api.downloadPlugin(download_request);
+
+        expect(response.status_code).toBe(HttpStatus::OK);
+        expect(response.body).toBe("{\"payload\":\"ABCDEabcde\",\"plugin_name\":\"cest\",\"version\":\"1.0\"}");
+    });
 });

--- a/tests/unit/http/test_endpoint.cpp
+++ b/tests/unit/http/test_endpoint.cpp
@@ -57,17 +57,6 @@ describe("Endpoint", []() {
         expect(match.isPresent()).toBe(false);
     });
 
-    xit("creates regex from path", []() {
-        expect(Endpoint::parsePath("/plain_path")).toBe("/plain_path");
-        expect(Endpoint::parsePath("/plain_path/:parameter")).toBe("/plain_path/[\\w-]+");
-    });
-
-
-    xit("creates regex from long path with multiple parameters", []() {
-        expect(Endpoint::parsePath("/plain_path")).toBe("/plain_path");
-        expect(Endpoint::parsePath("/leve1/:parameter1/level2/:parameter2")).toBe("/leve1/[\\w-]+/level2/[\\w-]+");
-    });
-
     it("returns match when path with one parameter match", []() {
         Endpoint endpoint("/plain_path/:parameter");
         Optional<struct HttpParameterMap> match;
@@ -78,14 +67,40 @@ describe("Endpoint", []() {
         expect(match.value().get("parameter")).toBe("value");
     });
 
-    it("returns match when path with many parameter matches", []() {
-        Endpoint endpoint("/leve1/:parameter1/level2/:parameter2");
+    it("returns match when path with one parameter match alphanumeric", []() {
+        Endpoint endpoint("/plain_path/:parameter");
         Optional<struct HttpParameterMap> match;
 
-        match = endpoint.match("/leve1/value1/level2/value2");
+        match = endpoint.match("/plain_path/3.7.3");
+
+        expect(match.isPresent()).toBe(true);
+        expect(match.value().get("parameter")).toBe("3.7.3");
+    });
+
+    it("returns match when path with many parameter matches", []() {
+        Endpoint endpoint("/leve1/:parameter1/:parameter2");
+        Optional<struct HttpParameterMap> match;
+
+        match = endpoint.match("/leve1/value1/3.7.3");
 
         expect(match.isPresent()).toBe(true);
         expect(match.value().get("parameter1")).toBe("value1");
-        expect(match.value().get("parameter2")).toBe("value2");
+        expect(match.value().get("parameter2")).toBe("3.7.3");
+    });
+
+    it("returns empty match when matching partial path with many parameter", []() {
+        Endpoint endpoint("/leve1/:parameter1/:parameter2");
+        Optional<struct HttpParameterMap> match;
+
+        match = endpoint.match("/leve1/value1");
+
+        expect(match.isPresent()).toBe(false);
+    });
+
+    it("compares two endpoints alphabetically by matching regex", []() {
+        Endpoint endpoint1("/plain_path/:parameter");
+        Endpoint endpoint2("/plain_path/:parameter/:parameter2");
+
+        expect(endpoint1 < endpoint2).toBe(true);
     });
 });

--- a/tests/unit/plugins/test_plugin_index.cpp
+++ b/tests/unit/plugins/test_plugin_index.cpp
@@ -29,7 +29,7 @@ describe("Plugins Repository in file system", []() {
     it("indexes one plugin", [&]() {
         PluginIndex plugin_index;
 
-        plugin_index.indexPlugin("cest", "user/cest/1.0");
+        plugin_index.indexPlugin("cest", std::string(), "user/cest/1.0");
 
         expect(plugin_index.serialize()).toBe(
             "{"
@@ -41,9 +41,9 @@ describe("Plugins Repository in file system", []() {
     it("updates plugin version when plugin is already inserted", [&]() {
         PluginIndex plugin_index;
 
-        plugin_index.indexPlugin("cest", "user/cest/0.1");
+        plugin_index.indexPlugin("cest", std::string(), "user/cest/0.1");
 
-        plugin_index.indexPlugin("cest", "user/cest/1.0");
+        plugin_index.indexPlugin("cest", std::string(), "user/cest/1.0");
 
         expect(plugin_index.serialize()).toBe(
             "{"
@@ -55,8 +55,8 @@ describe("Plugins Repository in file system", []() {
     it("indexes many plugins", [&]() {
         PluginIndex plugin_index;
 
-        plugin_index.indexPlugin("cest", "user/cest/1.0");
-        plugin_index.indexPlugin("fakeit", "user/fakeit/3.1");
+        plugin_index.indexPlugin("cest", std::string(), "user/cest/1.0");
+        plugin_index.indexPlugin("fakeit", std::string(), "user/fakeit/3.1");
 
         expect(plugin_index.serialize()).toBe(
             "{"
@@ -79,8 +79,8 @@ describe("Plugins Repository in file system", []() {
         PluginIndex plugin_index;
         Optional<string> directory;
 
-        plugin_index.indexPlugin("cest", "user/cest/1.0");
-        plugin_index.indexPlugin("fakeit", "user/fakeit/3.1");
+        plugin_index.indexPlugin("cest", std::string(), "user/cest/1.0");
+        plugin_index.indexPlugin("fakeit", std::string(), "user/fakeit/3.1");
 
         expect(plugin_index.find("cest").value()).toBe("user/cest/1.0");
         expect(plugin_index.find("fakeit").value()).toBe("user/fakeit/3.1");

--- a/tests/unit/plugins/test_plugin_index.cpp
+++ b/tests/unit/plugins/test_plugin_index.cpp
@@ -29,39 +29,29 @@ describe("Plugins Repository in file system", []() {
     it("indexes one plugin", [&]() {
         PluginIndex plugin_index;
 
-        plugin_index.indexPlugin("cest", std::string(), "user/cest/1.0");
+        plugin_index.indexPlugin("cest", std::string(), "user/cest");
 
         expect(plugin_index.serialize()).toBe(
-            "{"
-                "\"cest\":\"user/cest/1.0\""
-            "}"
-        );
-    });
-
-    it("updates plugin version when plugin is already inserted", [&]() {
-        PluginIndex plugin_index;
-
-        plugin_index.indexPlugin("cest", std::string(), "user/cest/0.1");
-
-        plugin_index.indexPlugin("cest", std::string(), "user/cest/1.0");
-
-        expect(plugin_index.serialize()).toBe(
-            "{"
-                "\"cest\":\"user/cest/1.0\""
-            "}"
+            "{\"__version__\":\"1\",\"cest\":{\"directory\":\"user/cest\",\"username\":\"\"}}"
         );
     });
 
     it("indexes many plugins", [&]() {
         PluginIndex plugin_index;
 
-        plugin_index.indexPlugin("cest", std::string(), "user/cest/1.0");
-        plugin_index.indexPlugin("fakeit", std::string(), "user/fakeit/3.1");
+        plugin_index.indexPlugin("cest", std::string(), "user/cest");
+        plugin_index.indexPlugin("fakeit", std::string(), "user/fakeit");
 
         expect(plugin_index.serialize()).toBe(
             "{"
-                "\"cest\":\"user/cest/1.0\","
-                "\"fakeit\":\"user/fakeit/3.1\""
+              "\"__version__\":\"1\","
+              "\"cest\":{"
+                "\"directory\":\"user/cest\","
+                "\"username\":\"\"},"
+              "\"fakeit\":{"
+                "\"directory\":\"user/fakeit\","
+                "\"username\":\"\""
+              "}"
             "}"
         );
     });

--- a/tests/unit/plugins/test_plugins_api.cpp
+++ b/tests/unit/plugins/test_plugins_api.cpp
@@ -100,15 +100,15 @@ describe("Plugins API", []() {
         Optional<Plugin> no_plugin;
 
         request.parameters.set("pluginName", "cest");
-        When(Method(mock_service, find)).Return(no_plugin);
+        When(OverloadedMethod(mock_service, find, Optional<Plugin>(string))).Return(no_plugin);
 
         response = api.downloadPlugin(request);
 
-        Verify(Method(mock_service, find).Using("cest"));
+        Verify(OverloadedMethod(mock_service, find, Optional<Plugin>(string)).Using("cest"));
         expect(response.status_code).toBe(404);
     });
             
-    it("returns plugin when downloading an existing plugin", [&]() {
+    it("returns latest plugin version when downloading an existing plugin", [&]() {
         HttpRequest request;
         HttpResponse response;
         Mock<PluginsService> mock_service;
@@ -117,16 +117,39 @@ describe("Plugins API", []() {
 
         request.parameters.set("pluginName", "cest");
         cest_plugin = Plugin("cest", "1.0", "user", "ABCDEabcde");
-        When(Method(mock_service, find)).Return(cest_plugin);
+        When(OverloadedMethod(mock_service, find, Optional<Plugin>(string))).Return(cest_plugin);
 
         response = api.downloadPlugin(request);
 
-        Verify(Method(mock_service, find).Using("cest"));
+        Verify(OverloadedMethod(mock_service, find, Optional<Plugin>(string)).Using("cest"));
         expect(response.status_code).toBe(200);
         expect(response.body).toBe("{"
             "\"payload\":\"ABCDEabcde\","
             "\"plugin_name\":\"cest\","
             "\"version\":\"1.0\""
+        "}");
+    });
+
+    it("returns specific plugin version when downloading an existing plugin", [&]() {
+        HttpRequest request;
+        HttpResponse response;
+        Mock<PluginsService> mock_service;
+        PluginsApi api(&mock_service.get());
+        Optional<Plugin> cest_plugin;
+
+        request.parameters.set("pluginName", "cest");
+        request.parameters.set("pluginVersion", "1.1");
+        cest_plugin = Plugin("cest", "1.1", "user", "ABCDEabcde");
+        When(OverloadedMethod(mock_service, find, Optional<Plugin>(string, string))).Return(cest_plugin);
+
+        response = api.downloadPlugin(request);
+
+        Verify(OverloadedMethod(mock_service, find, Optional<Plugin>(string, string)).Using("cest", "1.1"));
+        expect(response.status_code).toBe(200);
+        expect(response.body).toBe("{"
+            "\"payload\":\"ABCDEabcde\","
+            "\"plugin_name\":\"cest\","
+            "\"version\":\"1.1\""
         "}");
     });
 });

--- a/tests/unit/plugins/test_plugins_repository_in_filesystem.cpp
+++ b/tests/unit/plugins/test_plugins_repository_in_filesystem.cpp
@@ -22,9 +22,9 @@
 #include <plugins/PluginIndex.h>
 #include <plugins/PluginsRepositoryInFilesystem.h>
 
-using namespace std;
 using namespace cest;
 using namespace fakeit;
+using namespace std;
 
 
 describe("Plugins Repository in file system", []() {
@@ -47,7 +47,7 @@ describe("Plugins Repository in file system", []() {
         ));
         Verify(Method(mock_filesystem, writeFile).Using(
             "./index.json",
-            "{\"cest\":\"user/cest/1.0\"}"
+            "{\"__version__\":\"1\",\"cest\":{\"directory\":\"user/cest\",\"username\":\"user\"}}"
         ));
     });
 
@@ -66,11 +66,11 @@ describe("Plugins Repository in file system", []() {
 
         Verify(Method(mock_filesystem, writeFile).Using(
             "./index.json",
-            "{\"cest\":\"user/cest/0.1\"}"
+            "{\"__version__\":\"1\",\"cest\":{\"directory\":\"user/cest\",\"username\":\"user\"}}"
         )).AtLeastOnce();
         Verify(Method(mock_filesystem, writeFile).Using(
             "./index.json",
-            "{\"cest\":\"user/cest/1.0\"}"
+            "{\"__version__\":\"1\",\"cest\":{\"directory\":\"user/cest\",\"username\":\"user\"}}"
         )).AtLeastOnce();
     });
 
@@ -87,22 +87,23 @@ describe("Plugins Repository in file system", []() {
 
     it("finds an indexed plugin", [&]() {
         Mock<Filesystem> mock_filesystem;
-        Mock<PluginIndex> mock_plugin_index;
-        PluginsRepositoryInFilesystem repository(&mock_filesystem.get(), &mock_plugin_index.get());
+        PluginIndex plugin_index;
+        PluginsRepositoryInFilesystem repository(&mock_filesystem.get(), &plugin_index);
+        Plugin cest_plugin("cest", "0.1", "user", "cGx1Z2luIHBheWxvYWQ=");
         Optional<Plugin> plugin;
         Optional<string> directory;
 
-        directory = string("./user/cest/1.0");
-        When(Method(mock_plugin_index, find)).Return(directory);
+        directory = string("./user/cest");
+        When(Method(mock_filesystem, createDirectory)).AlwaysReturn();
+        When(Method(mock_filesystem, writeFile)).AlwaysReturn();
+        When(Method(mock_filesystem, listDirectories)).Return(list<string>{"user/cest/1.0"});
         When(Method(mock_filesystem, readFile))
                 .Return("{\"name\":\"cest\",\"user_name\":\"user\",\"version\":\"1.0\"}")
                 .Return("plugin payload");
 
-        try {
-            plugin = repository.find("cest");
-        } catch(std::exception e) {
-            cout << e.what() << endl;
-        }
+        repository.add(cest_plugin);
+
+        plugin = repository.find("cest");
 
         expect(plugin.value().metadata.name).toBe("cest");
         expect(plugin.value().metadata.version).toBe("1.0");
@@ -122,7 +123,7 @@ describe("Plugins Repository in file system", []() {
         repository.restore(".");
     });
 
-    it("finds an indexed plugin after index was restored from filesystem", [&]() {
+    it("finds an indexed plugin after index was restored from filesystem from version 0", [&]() {
         Mock<Filesystem> mock_filesystem;
         PluginIndex plugin_index;
         PluginsRepositoryInFilesystem repository(&mock_filesystem.get(), &plugin_index);
@@ -134,9 +135,35 @@ describe("Plugins Repository in file system", []() {
                 .Return("{\"cest\":\"user/cest/1.0\"}")
                 .Return("{\"name\":\"cest\",\"user_name\":\"user\",\"version\":\"1.0\"}")
                 .Return("plugin payload");
+        When(Method(mock_filesystem, listDirectories)).Return(list<string>{"1.0"});
 
         repository.restore(".");
         plugin = repository.find("cest");
+
+        expect(plugin.value().metadata.name).toBe("cest");
+        expect(plugin.value().metadata.version).toBe("1.0");
+        expect(plugin.value().metadata.user_name).toBe("user");
+        expect(plugin.value().payload).toBe("cGx1Z2luIHBheWxvYWQ=");
+    });
+
+    it("finds given version of an indexed plugin", [&]() {
+        Mock<Filesystem> mock_filesystem;
+        Mock<PluginIndex> mock_plugin_index;
+        PluginsRepositoryInFilesystem repository(&mock_filesystem.get(), &mock_plugin_index.get());
+        Optional<Plugin> plugin;
+        Optional<string> directory;
+
+        directory = string("./user/cest/1.0");
+        When(OverloadedMethod(mock_plugin_index, find, Optional<string>(string, string))).Return(directory);
+        When(Method(mock_filesystem, readFile))
+                .Return("{\"cest\": {\"username\": \"user\",\"directory\": \"user/cest\"}}")
+                .Return("plugin payload");
+
+        try {
+            plugin = repository.find("cest");
+        } catch(std::exception e) {
+            cout << e.what() << endl;
+        }
 
         expect(plugin.value().metadata.name).toBe("cest");
         expect(plugin.value().metadata.version).toBe("1.0");

--- a/tests/unit/plugins/test_plugins_repository_in_memory.cpp
+++ b/tests/unit/plugins/test_plugins_repository_in_memory.cpp
@@ -75,4 +75,51 @@ describe("Plugins Repository in Memory", []() {
 
         expect(stored_plugin.value().metadata.name).toBe(fakeit_plugin.metadata.name);
     });
+
+    it("doesn't find a plugin given version when it's not stored", [&]() {
+        PluginsRepositoryInMemory repository;
+        Plugin cest_plugin("cest");
+        Optional<Plugin> stored_plugin;
+
+        cest_plugin.metadata.version = "1.0";
+        repository.add(cest_plugin);
+
+        stored_plugin = repository.find("cest", "1.1");
+
+        expect(stored_plugin.isPresent()).toBe(false);
+    });
+
+    it("finds a plugin given version when it's stored", [&]() {
+        PluginsRepositoryInMemory repository;
+        Plugin cest_plugin_1_0("cest");
+        Plugin cest_plugin_1_1("cest");
+        Optional<Plugin> stored_plugin;
+
+        cest_plugin_1_1.metadata.version = "1.1";
+        repository.add(cest_plugin_1_1);
+        cest_plugin_1_0.metadata.version = "1.0";
+        repository.add(cest_plugin_1_0);
+
+        stored_plugin = repository.find("cest", "1.1");
+
+        expect(stored_plugin.isPresent()).toBe(true);
+        expect(stored_plugin.value().metadata.version).toBe("1.1");
+    });
+
+    it("finds the latest version of a plugin when many are stored but version is not specified", [&]() {
+        PluginsRepositoryInMemory repository;
+        Plugin cest_plugin_1_0("cest");
+        Plugin cest_plugin_1_1("cest");
+        Optional<Plugin> stored_plugin;
+
+        cest_plugin_1_1.metadata.version = "1.1";
+        repository.add(cest_plugin_1_1);
+        cest_plugin_1_0.metadata.version = "1.0";
+        repository.add(cest_plugin_1_0);
+
+        stored_plugin = repository.find("cest");
+
+        expect(stored_plugin.isPresent()).toBe(true);
+        expect(stored_plugin.value().metadata.version).toBe("1.1");
+    });
 });

--- a/tests/unit/plugins/test_plugins_service.cpp
+++ b/tests/unit/plugins/test_plugins_service.cpp
@@ -23,6 +23,7 @@
 
 using namespace cest;
 using namespace fakeit;
+using namespace std;
 
 
 describe("Plugins Service", []() {
@@ -62,9 +63,22 @@ describe("Plugins Service", []() {
         Optional<Plugin> plugin;
 
         plugin = Plugin("cest");
-        When(Method(mock_repository, find)).Return(plugin);
+        When(OverloadedMethod(mock_repository, find, Optional<Plugin>(string))).Return(plugin);
 
         auto found_plugin = plugins_service.find("cest");
+
+        expect(found_plugin.value().metadata.name).toBe("cest");
+    });
+
+    it("uses the repository to find a plugin by name and version", [&]() {
+        Mock<PluginsRepository> mock_repository;
+        PluginsService plugins_service(&mock_repository.get());
+        Optional<Plugin> plugin;
+
+        plugin = Plugin("cest");
+        When(OverloadedMethod(mock_repository, find, Optional<Plugin>(string, string))).Return(plugin);
+
+        auto found_plugin = plugins_service.find("cest", "1.1");
 
         expect(found_plugin.value().metadata.name).toBe("cest");
     });


### PR DESCRIPTION
With this pull request, a new endpoint `/plugins/:pluginName/:pluginVersion` is enabled that allows users to download specific plugin versions. It also enables support for storing multiple versions of a plugin in CPM Hub.

Closes #57 