### PR TITLE
Add support for user registration using invitation tokens

### DIFF
--- a/cpm-hub/authentication/AccessFileAuthenticator.cpp
+++ b/cpm-hub/authentication/AccessFileAuthenticator.cpp
@@ -83,3 +83,8 @@ bool AccessFileAuthenticator::validCredentials(UserCredentials &credentials)
 void AccessFileAuthenticator::addUser(UserCredentials &credentials)
 {
 }
+
+
+void AccessFileAuthenticator::addUserWithInvitation(UserCredentials &credentials, std::string invitation_token)
+{
+}

--- a/cpm-hub/authentication/AccessFileAuthenticator.h
+++ b/cpm-hub/authentication/AccessFileAuthenticator.h
@@ -35,6 +35,8 @@ public:
 
     bool validCredentials(UserCredentials &credentials);
 
+    virtual void addUserWithInvitation(UserCredentials &credentials, std::string invitation_token);
+
     void addUser(UserCredentials &credentials);
 
 private:

--- a/cpm-hub/authentication/Authenticator.h
+++ b/cpm-hub/authentication/Authenticator.h
@@ -29,6 +29,8 @@ public:
     virtual bool validCredentials(UserCredentials &credentials) = 0;
 
     virtual void addUser(UserCredentials &credentials) = 0;
+
+    virtual void addUserWithInvitation(UserCredentials &credentials, std::string invitation_token) = 0;
 };
 
 
@@ -43,6 +45,8 @@ public:
     }
 
     void addUser(UserCredentials &credentials) {}
+
+    void addUserWithInvitation(UserCredentials &credentials, std::string invitation_token) {}
 };
 
 
@@ -50,6 +54,21 @@ class AuthenticationFailure: public std::exception {
 public:
     AuthenticationFailure() throw() {
         sprintf(message, "unauthorized");
+    }
+
+    const char *what() const throw () {
+        return message;
+    }
+
+private:
+    char message[256];
+};
+
+
+class InvalidInvitationToken: public std::exception {
+public:
+    InvalidInvitationToken() throw() {
+        sprintf(message, "invalid invitation token");
     }
 
     const char *what() const throw () {

--- a/cpm-hub/authentication/CpmHubAuthenticator.cpp
+++ b/cpm-hub/authentication/CpmHubAuthenticator.cpp
@@ -88,3 +88,18 @@ void CpmHubAuthenticator::addUser(UserCredentials &credentials)
     this->client->post(this->users_endpoint, request);
 }
 
+
+void CpmHubAuthenticator::addUserWithInvitation(UserCredentials &credentials, std::string invitation_token)
+{
+    HttpRequest request(asJson(credentials));
+    HttpResponse response;
+
+    request.headers.set("Content-type", "application/json");
+    request.headers.set("OTP", invitation_token);
+    response = this->client->post(this->users_endpoint, request);
+
+    if (response.status_code == HttpStatus::UNAUTHORIZED) {
+        throw InvalidInvitationToken();
+    }
+}
+

--- a/cpm-hub/authentication/CpmHubAuthenticator.h
+++ b/cpm-hub/authentication/CpmHubAuthenticator.h
@@ -33,6 +33,8 @@ public:
 
     virtual void addUser(UserCredentials &credentials);
 
+    virtual void addUserWithInvitation(UserCredentials &credentials, std::string invitation_token);
+
 private:
     std::string authentication_endpoint;
     std::string users_endpoint;

--- a/cpm-hub/authentication/TrivialAuthenticator.cpp
+++ b/cpm-hub/authentication/TrivialAuthenticator.cpp
@@ -46,3 +46,8 @@ bool TrivialAuthenticator::validCredentials(UserCredentials &credentials)
 {
     return false;
 }
+
+
+void TrivialAuthenticator::addUserWithInvitation(UserCredentials &credentials, std::string invitation_token)
+{
+}

--- a/cpm-hub/authentication/TrivialAuthenticator.h
+++ b/cpm-hub/authentication/TrivialAuthenticator.h
@@ -29,6 +29,8 @@ public:
 
     virtual void addUser(UserCredentials &credentials);
 
+    virtual void addUserWithInvitation(UserCredentials &credentials, std::string invitation_token);
+
     bool validCredentials(UserCredentials &credentials);
 
 private:

--- a/cpm-hub/http/HttpResponse.h
+++ b/cpm-hub/http/HttpResponse.h
@@ -37,24 +37,33 @@ struct HttpResponse {
         body = _body;
     }
 
-    static HttpResponse unauthorized() {
+    static HttpResponse withEmptyBody(int status_code) {
         HttpResponse response;
-        response.status_code = HttpStatus::UNAUTHORIZED;
+        response.status_code = status_code;
         response.body = "";
         return response;
+    }
+
+    static HttpResponse badRequest() {
+        return withEmptyBody(HttpStatus::BAD_REQUEST);
+    }
+
+    static HttpResponse unauthorized() {
+        return withEmptyBody(HttpStatus::UNAUTHORIZED);
+    }
+
+    static HttpResponse conflict() {
+        return withEmptyBody(HttpStatus::CONFLICT);
+    }
+
+    static HttpResponse notFound() {
+        return withEmptyBody(HttpStatus::NOT_FOUND);
     }
 
     static HttpResponse ok(std::string body) {
         HttpResponse response;
         response.status_code = HttpStatus::OK;
         response.body = body;
-        return response;
-    }
-
-    static HttpResponse notFound() {
-        HttpResponse response;
-        response.status_code = HttpStatus::NOT_FOUND;
-        response.body = "";
         return response;
     }
 };

--- a/cpm-hub/http/http_status_codes.h
+++ b/cpm-hub/http/http_status_codes.h
@@ -23,6 +23,7 @@ namespace HttpStatus {
         BAD_REQUEST = 400,
         UNAUTHORIZED = 401,
         NOT_FOUND = 404,
+        CONFLICT = 409,
         INTERNAL_SERVER_ERROR = 500
     };
 }

--- a/cpm-hub/management/http_routes.cpp
+++ b/cpm-hub/management/http_routes.cpp
@@ -16,12 +16,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include <management/http_routes.h>
+#include <users/rest_api/UsersApi.h>
 
 
 using namespace std;
 
 
-void installServiceRoutes(HttpServer& http_server, BitsApi *bits_api)
+void installServiceRoutes(HttpServer &http_server, BitsApi *bits_api, UsersApi *users_api)
 {
     http_server.post("/bits", [bits_api](HttpRequest &request) -> HttpResponse {
         return bits_api->publishBit(request);
@@ -31,6 +32,9 @@ void installServiceRoutes(HttpServer& http_server, BitsApi *bits_api)
     });
     http_server.get("/bits/:bitName/:bitVersion", [bits_api](HttpRequest &request) -> HttpResponse {
         return bits_api->downloadBit(request);
+    });
+    http_server.post("/users", [users_api](HttpRequest &request) -> HttpResponse {
+        return users_api->registerUser(request);
     });
 }
 

--- a/cpm-hub/management/http_routes.h
+++ b/cpm-hub/management/http_routes.h
@@ -23,8 +23,9 @@
 #include <http/HttpServer.h>
 #include <bits/rest_api/BitsApi.h>
 #include <management/rest_api/ManagementApi.h>
+#include <users/rest_api/UsersApi.h>
 
 
-void installServiceRoutes(HttpServer& http_server, BitsApi *bits_api);
+void installServiceRoutes(HttpServer &http_server, BitsApi *bits_api, UsersApi *users_api);
 
 void installManagementRoutes(HttpServer &http_server, ManagementApi *management_api);

--- a/cpm-hub/users/UserRegistrationData.h
+++ b/cpm-hub/users/UserRegistrationData.h
@@ -20,10 +20,8 @@
 #include <string>
 
 
-#define kMAX_PASSWORD_LENGTH    64
-
-
 struct UserRegistrationData {
+    std::string invitation_token;
     std::string username;
     std::string password;
     std::string email;

--- a/cpm-hub/users/UsersService.cpp
+++ b/cpm-hub/users/UsersService.cpp
@@ -34,7 +34,7 @@ User UsersService::registerUser(UserRegistrationData &registration_data)
         throw UsernameAlreadyTaken(registration_data.username);
     }
 
-    this->authenticator->addUser(credentials);
+    this->authenticator->addUserWithInvitation(credentials, registration_data.invitation_token);
     this->users_repository->add(user);
 
     return user;

--- a/cpm-hub/users/rest_api/UsersApi.h
+++ b/cpm-hub/users/rest_api/UsersApi.h
@@ -24,12 +24,10 @@
 
 class UsersApi {
 public:
-    UsersApi(UsersService *users_service, Authenticator *authenticator);
+    UsersApi(UsersService *users_service);
 
     HttpResponse registerUser(HttpRequest &request);
 
 private:
     UsersService *users_service;
-
-    Authenticator *authenticator;
 };

--- a/tests/integration/test_users.cpp
+++ b/tests/integration/test_users.cpp
@@ -27,22 +27,21 @@ using namespace cest;
 
 
 describe("CPM Hub users management", []() {
-    it("registers a user when api_key is valid", [&]() {
-        HttpRequest request("{"
-            "\"username\": \"juancho\","
-            "\"password\": \"123456\","
-            "\"email\": \"juancho@encho.com\""
-        "}");
-        HttpResponse response;
+    it("registers a user when otp is valid", [&]() {
         TrivialAuthenticator management_authenticator;
         UsersRepositoryInMemory repository;
         NullAuthenticator service_authenticator;
         UsersService service(&repository, &service_authenticator);
-        UsersApi api(&service, &management_authenticator);
-        UserCredentials credentials = {"admin", "cafecafe"};
+        UsersApi api(&service);
+        HttpRequest request("{"
+                            "\"invitation_token\": \"cafecafe\","
+                            "\"username\": \"juancho\","
+                            "\"password\": \"123456\","
+                            "\"email\": \"juancho@encho.com\""
+                            "}");
+        HttpResponse response;
 
-        management_authenticator.addUser(credentials);
-        request.headers.set("API_KEY", "cafecafe");
+        request.headers.set("OTP", "cafecafe");
 
         response = api.registerUser(request);
 

--- a/tests/unit/users/test_users_service.cpp
+++ b/tests/unit/users/test_users_service.cpp
@@ -33,7 +33,7 @@ describe("Users Service", []() {
         Mock<CpmHubAuthenticator> user_authenticator;
         UsersService users_service(&mock_repository.get(), &user_authenticator.get());
         struct UserRegistrationData registration_data = {
-            "sotano", "654321", "sotano@example.com"
+            "invitation_token", "sotano", "654321", "sotano@example.com"
         };
         User stored_user("");
 
@@ -41,13 +41,13 @@ describe("Users Service", []() {
         When(Method(mock_repository, add)).AlwaysDo([&](User &user) {
             stored_user = user;
         });
-        When(Method(user_authenticator, addUser)).Return();
+        When(Method(user_authenticator, addUserWithInvitation)).Return();
 
         users_service.registerUser(registration_data);
 
         expect(stored_user.name).toBe("sotano");
         Verify(Method(mock_repository, add));
-        Verify(Method(user_authenticator, addUser));
+        Verify(Method(user_authenticator, addUserWithInvitation));
     });
 
     it("throws an exception when registering a user whose user name is taken", [&]() {


### PR DESCRIPTION
This pull request opens a new `/users` endpoint and allows user registration through it via inviation token. The registration currently only is useful for having authorization for publishing bits into cpmbits.