### PR TITLE
Implement cors pre-flight request handling

### DIFF
--- a/cpm-hub/http/HttpResource.h
+++ b/cpm-hub/http/HttpResource.h
@@ -41,6 +41,20 @@ public:
     }
 
     virtual HttpResponse options(HttpRequest &request) {
-        return HttpResponse::notFound();
+        HttpResponse response = HttpResponse::noContent();
+        if (request.headers.has("Access-Control-Request-Method")) {
+            response.headers.set("Access-Control-Allow-Methods", allow_methods);
+        }
+        if (request.headers.has("Origin")) {
+            response.headers.set("Access-Control-Allow-Origin", origin);
+        }
+        if (request.headers.has("Access-Control-Request-Headers")) {
+            response.headers.set("Access-Control-Allow-Headers", "*");
+        }
+        return response;
     }
+
+    std::string allow_methods = "";
+    std::string allow_headers = "*";
+    std::string origin;
 };

--- a/cpm-hub/http/HttpResource.h
+++ b/cpm-hub/http/HttpResource.h
@@ -44,17 +44,20 @@ public:
         HttpResponse response = HttpResponse::noContent();
         if (request.headers.has("Access-Control-Request-Method")) {
             response.headers.set("Access-Control-Allow-Methods", allow_methods);
+            response.headers.set("Access-Control-Max-Age", "86400");
         }
         if (request.headers.has("Origin")) {
-            response.headers.set("Access-Control-Allow-Origin", origin);
+            response.headers.set("Access-Control-Allow-Origin", allow_origin);
+            response.headers.set("Access-Control-Max-Age", "86400");
         }
         if (request.headers.has("Access-Control-Request-Headers")) {
-            response.headers.set("Access-Control-Allow-Headers", "*");
+            response.headers.set("Access-Control-Allow-Headers", allow_headers);
+            response.headers.set("Access-Control-Max-Age", "86400");
         }
         return response;
     }
 
     std::string allow_methods = "";
     std::string allow_headers = "*";
-    std::string origin;
+    std::string allow_origin;
 };

--- a/cpm-hub/http/HttpResponse.h
+++ b/cpm-hub/http/HttpResponse.h
@@ -69,6 +69,13 @@ struct HttpResponse {
         return response;
     }
 
+    static HttpResponse noContent() {
+        HttpResponse response;
+        response.status_code = HttpStatus::NO_CONTENT;
+        response.body = "";
+        return response;
+    }
+
     static HttpResponse cors(std::string origin, std::string methods) {
         HttpResponse response;
         response.status_code = HttpStatus::NO_CONTENT;

--- a/cpm-hub/http/HttpResponse.h
+++ b/cpm-hub/http/HttpResponse.h
@@ -68,4 +68,14 @@ struct HttpResponse {
         response.body = body;
         return response;
     }
+
+    static HttpResponse cors(std::string origin, std::string methods) {
+        HttpResponse response;
+        response.status_code = HttpStatus::NO_CONTENT;
+        response.body = "";
+        response.headers.set("Access-Control-Allow-Origin", origin);
+        response.headers.set("Access-Control-Allow-Methods", methods);
+        response.headers.set("Access-Control-Max-Age", "86400");
+        return response;
+    }
 };

--- a/cpm-hub/http/http_status_codes.h
+++ b/cpm-hub/http/http_status_codes.h
@@ -20,6 +20,7 @@
 namespace HttpStatus {
     enum {
         OK = 200,
+        NO_CONTENT = 204,
         BAD_REQUEST = 400,
         UNAUTHORIZED = 401,
         NOT_FOUND = 404,

--- a/tests/unit/http/test_http_server.cpp
+++ b/tests/unit/http/test_http_server.cpp
@@ -260,13 +260,15 @@ describe("HTTP server using resources", []() {
         HttpResponse response;
         HttpResource resource;
 
+        resource.allow_methods = "GET, POST";
+        resource.allow_origin = "*";
         request.headers.set("Access-Control-Request-Method", "POST");
         request.headers.set("Access-Control-Request-Headers", "origin");
         request.headers.set("Origin", "https://cpmbits.com");
         server.addResource(Endpoint("/bits"), &resource);
         server.startAsync("127.0.0.1", 8000);
 
-        response = client.method("http://127.0.0.1:8000/bits", HttpRequest(""), "OPTIONS");
+        response = client.method("http://127.0.0.1:8000/bits", request, "OPTIONS");
 
         expect(response.status_code).toBe(HttpStatus::NO_CONTENT);
         expect(response.body).toBe("");

--- a/tests/unit/http/test_http_server.cpp
+++ b/tests/unit/http/test_http_server.cpp
@@ -258,12 +258,12 @@ describe("HTTP server using resources", []() {
         HttpClient client;
         HttpRequest request;
         HttpResponse response;
+        HttpResource resource;
 
         request.headers.set("Access-Control-Request-Method", "POST");
         request.headers.set("Access-Control-Request-Headers", "origin");
         request.headers.set("Origin", "https://cpmbits.com");
-        test_resource->options_response = HttpResponse::cors("*", "GET, POST");
-        server.addResource(Endpoint("/bits"), test_resource);
+        server.addResource(Endpoint("/bits"), &resource);
         server.startAsync("127.0.0.1", 8000);
 
         response = client.method("http://127.0.0.1:8000/bits", HttpRequest(""), "OPTIONS");

--- a/tests/unit/http/test_http_server.cpp
+++ b/tests/unit/http/test_http_server.cpp
@@ -95,7 +95,7 @@ describe("HTTP server using resources", []() {
 
         response = client.get("http://127.0.0.1:8000/bits", HttpRequest(""));
 
-        expect(response.status_code).toBe(404);
+        expect(response.status_code).toBe(HttpStatus::NOT_FOUND);
 
         server.stop();
     });
@@ -111,7 +111,7 @@ describe("HTTP server using resources", []() {
 
         response = client.get("http://127.0.0.1:8000/bits", HttpRequest(""));
 
-        expect(response.status_code).toBe(200);
+        expect(response.status_code).toBe(HttpStatus::OK);
         expect(response.body).toBe("hello");
 
         server.stop();
@@ -128,7 +128,7 @@ describe("HTTP server using resources", []() {
 
         response = client.post("http://127.0.0.1:8000/bits", HttpRequest(""));
 
-        expect(response.status_code).toBe(200);
+        expect(response.status_code).toBe(HttpStatus::OK);
         expect(response.body).toBe("hello");
 
         server.stop();
@@ -145,7 +145,7 @@ describe("HTTP server using resources", []() {
 
         response = client.put("http://127.0.0.1:8000/bits", HttpRequest(""));
 
-        expect(response.status_code).toBe(200);
+        expect(response.status_code).toBe(HttpStatus::OK);
         expect(response.body).toBe("hello");
 
         server.stop();
@@ -162,7 +162,7 @@ describe("HTTP server using resources", []() {
 
         response = client.method("http://127.0.0.1:8000/bits", HttpRequest(""), "OPTIONS");
 
-        expect(response.status_code).toBe(200);
+        expect(response.status_code).toBe(HttpStatus::OK);
         expect(response.body).toBe("GET, POST, PUT");
 
         server.stop();
@@ -216,7 +216,7 @@ describe("HTTP server using resources", []() {
 
         response = client.method("http://127.0.0.1:8000/bits", HttpRequest("post data"), "CONNECT");
 
-        expect(response.status_code).toBe(400);
+        expect(response.status_code).toBe(HttpStatus::BAD_REQUEST);
 
         server.stop();
     });
@@ -232,7 +232,7 @@ describe("HTTP server using resources", []() {
 
         response = client.post("http://127.0.0.1:8000/bits", HttpRequest("post data"));
 
-        expect(response.status_code).toBe(404);
+        expect(response.status_code).toBe(HttpStatus::NOT_FOUND);
 
         server.stop();
     });
@@ -248,7 +248,31 @@ describe("HTTP server using resources", []() {
 
         response = client.get("http://127.0.0.1:8000/bits", HttpRequest(""));
 
-        expect(response.status_code).toBe(500);
+        expect(response.status_code).toBe(HttpStatus::INTERNAL_SERVER_ERROR);
+
+        server.stop();
+    });
+
+    it("handles CORS pre-flight request", []() {
+        HttpServer server;
+        HttpClient client;
+        HttpRequest request;
+        HttpResponse response;
+
+        request.headers.set("Access-Control-Request-Method", "POST");
+        request.headers.set("Access-Control-Request-Headers", "origin");
+        request.headers.set("Origin", "https://cpmbits.com");
+        test_resource->options_response = HttpResponse::cors("*", "GET, POST");
+        server.addResource(Endpoint("/bits"), test_resource);
+        server.startAsync("127.0.0.1", 8000);
+
+        response = client.method("http://127.0.0.1:8000/bits", HttpRequest(""), "OPTIONS");
+
+        expect(response.status_code).toBe(HttpStatus::NO_CONTENT);
+        expect(response.body).toBe("");
+        expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+        expect(response.headers.get("Access-Control-Allow-Methods")).toBe("GET, POST");
+        expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
 
         server.stop();
     });


### PR DESCRIPTION
This pull request implements a trivial handling of a CORS pre-flight request. The response to such request will always be fixed according to what is declared in the specific `HttpResource`.