### PR TITLE
Allow binding servers to configured IP address

### DIFF
--- a/cpm-hub/management/ProgramOptions.h
+++ b/cpm-hub/management/ProgramOptions.h
@@ -31,7 +31,9 @@ struct ProgramOptions {
     AuthenticatorType authenticator_type = UNAUTHENTICATED;
     std::string access_file = ".access";
     std::string cpm_hub_url = "http://localhost:1234";
+    std::string http_service_ip = "127.0.0.1";
     int http_service_port = 8000;
+    std::string http_management_ip = "127.0.0.1";
     int http_management_port = 8001;
     HttpSecurityOptions security_options;
 

--- a/cpm-hub/management/cpm_hub_starter.cpp
+++ b/cpm-hub/management/cpm_hub_starter.cpp
@@ -73,7 +73,7 @@ void startServiceServer(ProgramOptions &options)
 
     installServiceRoutes(service_http_server, bits_resource, users_resource);
     service_http_server.configureSecurity(options.security_options);
-    service_http_server.startAsync("0.0.0.0", options.http_service_port);
+    service_http_server.startAsync(options.http_service_ip, options.http_service_port);
 }
 
 
@@ -88,7 +88,7 @@ void startManagementServer(ProgramOptions &options, std::vector<std::string> com
 
     installManagementRoutes(management_http_server, management_resource);
     management_http_server.configureSecurity(options.security_options);
-    management_http_server.start("0.0.0.0", options.http_management_port);
+    management_http_server.start(options.http_management_ip, options.http_management_port);
 }
 
 

--- a/cpm-hub/management/program_options_parser.cpp
+++ b/cpm-hub/management/program_options_parser.cpp
@@ -35,9 +35,11 @@ static ProgramOptions parseIniFile(string &ini_file)
     INIReader ini_reader(ini_file);
 
     program_options.bits_directory = ini_reader.Get("Service", "bits_directory", ".");
+    program_options.http_service_ip = ini_reader.Get("Service", "ip_bind", "127.0.0.1");
     program_options.http_service_port = ini_reader.GetInteger("Service", "port", 8000);
     program_options.authenticator_type = string_to_authenticator_type[ini_reader.Get("Service", "authentication", "unauthenticated")];
     program_options.cpm_hub_url = ini_reader.Get("Service", "cpm_hub_url", "http://localhost:1234");
+    program_options.http_management_ip = ini_reader.Get("Management", "ip_bind", "127.0.0.1");
     program_options.http_management_port = ini_reader.GetInteger("Management", "port", 8001);
     program_options.security_options.security_enabled = ini_reader.GetBoolean("Management", "security_enabled", false);
     program_options.security_options.certificate_file = ini_reader.Get("Management", "certificate_file", "certificate.pem");

--- a/tests/staging/cpmhub.ini
+++ b/tests/staging/cpmhub.ini
@@ -1,5 +1,6 @@
 [Service]
 plugins_directory = tests/staging/data
+ip_bind = 127.0.0.1
 port = 8000
 access_file = .access_file
 authentication = cpm_hub_auth


### PR DESCRIPTION
This PR allows configuring the IP bind for both management and service servers though `cpmhub.ini`.