### PR TITLE
Allow searching bits by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ cmake-build-build/
 .idea/
 .vscode/
 CMakeLists.txt
+bits

--- a/cpm-hub/bits/BitIndex.cpp
+++ b/cpm-hub/bits/BitIndex.cpp
@@ -23,9 +23,9 @@ using namespace std;
 using namespace nlohmann;
 
 
-void BitIndex::indexBit(string name, string username, std::string directory)
+void BitIndex::indexBit(string name, string username, string directory)
 {
-    BitIndexEntry index_entry = {username, directory};
+    BitIndexEntry index_entry = {name, username, directory};
 
     this->bits[name] = index_entry;
 }
@@ -64,7 +64,7 @@ string BitIndex::serialize()
 }
 
 
-void BitIndex::restore(std::string serialized)
+void BitIndex::restore(string serialized)
 {
     auto json = json::parse(serialized);
 
@@ -81,7 +81,7 @@ void BitIndex::restore(std::string serialized)
 }
 
 
-void BitIndex::restoreFromVersion0(std::string serialized)
+void BitIndex::restoreFromVersion0(string serialized)
 {
     auto json = json::parse(serialized);
 
@@ -92,4 +92,17 @@ void BitIndex::restoreFromVersion0(std::string serialized)
         boost::split(tokens, directory, boost::is_any_of("/"));
         this->indexBit(element.key(), tokens.at(0), tokens.at(0)+"/"+tokens.at(1));
     }
+}
+
+list<BitIndexEntry> BitIndex::search(BitSearchQuery search_query)
+{
+    list<BitIndexEntry> found_bits;
+
+    for (auto &bit_map: this->bits) {
+        if (bit_map.first.find(search_query.name) != string::npos) {
+            found_bits.push_back(bit_map.second);
+        }
+    }
+
+    return found_bits;
 }

--- a/cpm-hub/bits/BitIndex.h
+++ b/cpm-hub/bits/BitIndex.h
@@ -24,9 +24,11 @@
 #include <infrastructure/Optional.h>
 #include <infrastructure/Filesystem.h>
 #include <bits/BitMetadata.h>
+#include <bits/BitSearchQuery.h>
 
 
 struct BitIndexEntry {
+    std::string name;
     std::string username;
     std::string directory;
 };
@@ -41,6 +43,8 @@ public:
     virtual std::string serialize();
 
     virtual void restore(std::string serialized);
+
+    virtual std::list<BitIndexEntry> search(BitSearchQuery search_query);
 
 private:
     const std::string index_version = "1";

--- a/cpm-hub/bits/BitSearchQuery.h
+++ b/cpm-hub/bits/BitSearchQuery.h
@@ -17,26 +17,8 @@
  */
 #pragma once
 
-#include <map>
-#include <list>
 #include <string>
-#include <bits/BitsRepository.h>
 
-
-class BitsRepositoryInMemory: public BitsRepository {
-public:
-    virtual void add(Bit &bit);
-
-    virtual Optional<Bit> bitBy(std::string name);
-
-    virtual Optional<Bit> bitBy(std::string name, std::string version);
-
-    virtual std::list<Bit> allBits();
-
-    virtual std::list<BitMetadata> search(BitSearchQuery search_query);
-
-private:
-    std::map<std::string, std::list<Bit>> bits;
-
-    bool bitExists(const Bit &bit) const;
+struct BitSearchQuery {
+    std::string name;
 };

--- a/cpm-hub/bits/BitsRepository.h
+++ b/cpm-hub/bits/BitsRepository.h
@@ -21,6 +21,7 @@
 #include <list>
 
 #include <infrastructure/Optional.h>
+#include <bits/BitSearchQuery.h>
 #include <bits/Bit.h>
 
 
@@ -28,9 +29,11 @@ class BitsRepository {
 public:
     virtual void add(Bit &bit) = 0;
 
-    virtual Optional<Bit> find(std::string name) = 0;
+    virtual Optional<Bit> bitBy(std::string name) = 0;
 
-    virtual Optional<Bit> find(std::string name, std::string version) = 0;
+    virtual Optional<Bit> bitBy(std::string name, std::string version) = 0;
 
-    virtual std::list<Bit>allBits() = 0;
+    virtual std::list<BitMetadata> search(BitSearchQuery search_query) = 0;
+
+    virtual std::list<Bit> allBits() = 0;
 };

--- a/cpm-hub/bits/BitsRepositoryInFilesystem.cpp
+++ b/cpm-hub/bits/BitsRepositoryInFilesystem.cpp
@@ -89,7 +89,7 @@ void BitsRepositoryInFilesystem::saveMetadata(const string& name, const string& 
 }
 
 
-Optional<Bit> BitsRepositoryInFilesystem::bitBy(std::string name)
+Optional<Bit> BitsRepositoryInFilesystem::bitBy(string name)
 {
     Optional<Bit> bit;
     Optional<string> index_directory;
@@ -117,7 +117,7 @@ string BitsRepositoryInFilesystem::latestVersionDirectory(string base_directory)
 }
 
 
-Optional<Bit> BitsRepositoryInFilesystem::bitBy(std::string name, std::string version)
+Optional<Bit> BitsRepositoryInFilesystem::bitBy(string name, string version)
 {
     Optional<Bit> bit;
     Optional<string> base_directory;
@@ -176,7 +176,17 @@ void BitsRepositoryInFilesystem::restore(string directory)
 }
 
 
-std::list<BitMetadata> BitsRepositoryInFilesystem::search(BitSearchQuery search_query)
+list<BitMetadata> BitsRepositoryInFilesystem::search(BitSearchQuery search_query)
 {
-    return std::list<BitMetadata>();
+    list<BitMetadata> search_results;
+    list<BitIndexEntry> index_results;
+    string bit_directory;
+
+    index_results = this->index->search(search_query);
+    for (auto &bit_entry: index_results) {
+        bit_directory = latestVersionDirectory(this->directory + "/" + bit_entry.directory);
+        search_results.push_back(this->loadMetadata(bit_entry.name, bit_directory));
+    }
+
+    return search_results;
 }

--- a/cpm-hub/bits/BitsRepositoryInFilesystem.cpp
+++ b/cpm-hub/bits/BitsRepositoryInFilesystem.cpp
@@ -89,7 +89,7 @@ void BitsRepositoryInFilesystem::saveMetadata(const string& name, const string& 
 }
 
 
-Optional<Bit> BitsRepositoryInFilesystem::find(std::string name)
+Optional<Bit> BitsRepositoryInFilesystem::bitBy(std::string name)
 {
     Optional<Bit> bit;
     Optional<string> index_directory;
@@ -117,7 +117,7 @@ string BitsRepositoryInFilesystem::latestVersionDirectory(string base_directory)
 }
 
 
-Optional<Bit> BitsRepositoryInFilesystem::find(std::string name, std::string version)
+Optional<Bit> BitsRepositoryInFilesystem::bitBy(std::string name, std::string version)
 {
     Optional<Bit> bit;
     Optional<string> base_directory;
@@ -173,4 +173,10 @@ void BitsRepositoryInFilesystem::restore(string directory)
     if (this->filesystem->fileExists(this->index_file)) {
         this->index->restore(this->filesystem->readFile(this->index_file));
     }
+}
+
+
+std::list<BitMetadata> BitsRepositoryInFilesystem::search(BitSearchQuery search_query)
+{
+    return std::list<BitMetadata>();
 }

--- a/cpm-hub/bits/BitsRepositoryInFilesystem.h
+++ b/cpm-hub/bits/BitsRepositoryInFilesystem.h
@@ -32,9 +32,11 @@ public:
 
     virtual void add(Bit &bit);
 
-    virtual Optional<Bit> find(std::string name);
+    virtual Optional<Bit> bitBy(std::string name);
 
-    virtual Optional<Bit> find(std::string name, std::string version);
+    virtual Optional<Bit> bitBy(std::string name, std::string version);
+
+    virtual std::list<BitMetadata> search(BitSearchQuery search_query);
 
     virtual std::list<Bit> allBits();
 

--- a/cpm-hub/bits/BitsRepositoryInMemory.cpp
+++ b/cpm-hub/bits/BitsRepositoryInMemory.cpp
@@ -43,7 +43,7 @@ bool BitsRepositoryInMemory::bitExists(const Bit &bit) const
 }
 
 
-Optional<Bit> BitsRepositoryInMemory::find(string name)
+Optional<Bit> BitsRepositoryInMemory::bitBy(string name)
 {
     Optional<Bit> bit;
 
@@ -57,7 +57,7 @@ Optional<Bit> BitsRepositoryInMemory::find(string name)
 }
 
 
-Optional<Bit> BitsRepositoryInMemory::find(string name, string version)
+Optional<Bit> BitsRepositoryInMemory::bitBy(string name, string version)
 {
     Optional<Bit> bit;
 
@@ -86,4 +86,18 @@ list<Bit> BitsRepositoryInMemory::allBits()
     }
 
     return stored_bits;
+}
+
+
+list<BitMetadata> BitsRepositoryInMemory::search(BitSearchQuery search_query)
+{
+    list<BitMetadata> found_bits;
+
+    for (auto &bit_map: this->bits) {
+        if (bit_map.first.find(search_query.name) != string::npos) {
+            found_bits.push_back(bit_map.second.front().metadata);
+        }
+    }
+
+    return found_bits;
 }

--- a/cpm-hub/bits/BitsService.cpp
+++ b/cpm-hub/bits/BitsService.cpp
@@ -59,5 +59,5 @@ Optional<Bit> BitsService::bitBy(std::string bit_name, std::string version)
 
 std::list<BitMetadata> BitsService::search(BitSearchQuery search_query)
 {
-    return std::list<BitMetadata>();
+    return bits_repository->search(search_query);
 }

--- a/cpm-hub/bits/BitsService.cpp
+++ b/cpm-hub/bits/BitsService.cpp
@@ -45,13 +45,19 @@ list<Bit> BitsService::allBits()
 }
 
 
-Optional<Bit> BitsService::find(std::string bit_name)
+Optional<Bit> BitsService::bitBy(std::string bit_name)
 {
-    return bits_repository->find(bit_name);
+    return bits_repository->bitBy(bit_name);
 }
 
 
-Optional<Bit> BitsService::find(std::string bit_name, std::string version)
+Optional<Bit> BitsService::bitBy(std::string bit_name, std::string version)
 {
-    return bits_repository->find(bit_name, version);
+    return bits_repository->bitBy(bit_name, version);
+}
+
+
+std::list<BitMetadata> BitsService::search(BitSearchQuery search_query)
+{
+    return std::list<BitMetadata>();
 }

--- a/cpm-hub/bits/BitsService.h
+++ b/cpm-hub/bits/BitsService.h
@@ -22,6 +22,7 @@
 
 #include <infrastructure/Optional.h>
 #include <bits/BitPublicationData.h>
+#include <bits/BitSearchQuery.h>
 #include <bits/BitsRepository.h>
 #include <bits/Bit.h>
 
@@ -33,9 +34,11 @@ public:
 
     virtual std::list<Bit> allBits();
     
-    virtual Optional<Bit> find(std::string bit_name);
+    virtual Optional<Bit> bitBy(std::string bit_name);
 
-    virtual Optional<Bit> find(std::string name, std::string version);
+    virtual Optional<Bit> bitBy(std::string bit_name, std::string version);
+
+    virtual std::list<BitMetadata> search(BitSearchQuery search_query);
 
 private:
     BitsRepository *bits_repository;

--- a/cpm-hub/bits/rest_api/BitsHttpResource.cpp
+++ b/cpm-hub/bits/rest_api/BitsHttpResource.cpp
@@ -143,7 +143,15 @@ HttpResponse BitsHttpResource::searchForBit(HttpRequest &request)
     list<BitMetadata> bits_found;
     BitSearchQuery search_query;
 
+    if (!request.query_parameters.has("name")) {
+        return HttpResponse::badRequest();
+    }
+
     search_query.name = request.query_parameters.get("name");
+    if (search_query.name.empty()) {
+        return HttpResponse::badRequest();
+    }
+
     bits_found = this->bits_service->search(search_query);
 
     return HttpResponse::ok(bitSearchResultsAsJson(bits_found));

--- a/cpm-hub/bits/rest_api/BitsHttpResource.cpp
+++ b/cpm-hub/bits/rest_api/BitsHttpResource.cpp
@@ -56,7 +56,7 @@ HttpResponse BitsHttpResource::post(HttpRequest &request)
     publication_data.user_name = json.at("username");
     publication_data.payload = json.at("payload");
 
-    if (this->bits_service->find(publication_data.bit_name, publication_data.version).isPresent()) {
+    if (this->bits_service->bitBy(publication_data.bit_name, publication_data.version).isPresent()) {
         return HttpResponse::conflict();
     }
 
@@ -80,25 +80,35 @@ HttpResponse BitsHttpResource::listBits(HttpRequest &request)
 }
 
 
-static string asJson(Bit bit)
+HttpResponse BitsHttpResource::get(HttpRequest &request)
+{
+    if (!request.parameters.has("bitName")) {
+        return searchForBit(request);
+    } else {
+        return getBit(request);
+    }
+}
+
+
+static string bitAsJson(Bit &bit)
 {
     json json_bit = {
-        {"bit_name", bit.metadata.name},
-        {"version", bit.metadata.version},
-        {"payload", bit.payload}
+            {"bit_name", bit.metadata.name},
+            {"version", bit.metadata.version},
+            {"payload", bit.payload}
     };
     return json_bit.dump();
 }
 
 
-HttpResponse BitsHttpResource::get(HttpRequest &request)
+HttpResponse BitsHttpResource::getBit(HttpRequest &request)
 {
     Optional<Bit> bit;
 
     if (!request.parameters.has("bitVersion")) {
-        bit = bits_service->find(request.parameters.get("bitName"));
+        bit = this->bits_service->bitBy(request.parameters.get("bitName"));
     } else {
-        bit = bits_service->find(
+        bit = this->bits_service->bitBy(
                 request.parameters.get("bitName"),
                 request.parameters.get("bitVersion"));
     }
@@ -107,5 +117,34 @@ HttpResponse BitsHttpResource::get(HttpRequest &request)
         return HttpResponse(HttpStatus::NOT_FOUND, "");
     }
 
-    return HttpResponse(HttpStatus::OK, asJson(bit.value()));
+    return HttpResponse::ok(bitAsJson(bit.value()));
+}
+
+
+static string bitSearchResultsAsJson(list<BitMetadata> &bits_found)
+{
+    HttpResponse response;
+    json json_bits = json::array();
+
+    for (auto &bit : bits_found) {
+        json json_bit = {
+            {"name", bit.name},
+            {"author", bit.user_name}
+        };
+        json_bits.push_back(json_bit);
+    }
+
+    return json_bits.dump();
+}
+
+
+HttpResponse BitsHttpResource::searchForBit(HttpRequest &request)
+{
+    list<BitMetadata> bits_found;
+    BitSearchQuery search_query;
+
+    search_query.name = request.query_parameters.get("name");
+    bits_found = this->bits_service->search(search_query);
+
+    return HttpResponse::ok(bitSearchResultsAsJson(bits_found));
 }

--- a/cpm-hub/bits/rest_api/BitsHttpResource.h
+++ b/cpm-hub/bits/rest_api/BitsHttpResource.h
@@ -38,4 +38,8 @@ private:
     BitsService *bits_service;
 
     Authenticator *authenticator;
+
+    HttpResponse searchForBit(HttpRequest &request);
+
+    HttpResponse getBit(HttpRequest &request);
 };

--- a/tests/integration/test_bits.cpp
+++ b/tests/integration/test_bits.cpp
@@ -166,6 +166,6 @@ describe("CPM Hub bits management", []() {
         response = api.get(search_request);
 
         expect(response.status_code).toBe(HttpStatus::OK);
-        expect(response.body).toBe("[{\"name\":\"cest\",\"author\":\"john_doe\"}]");
+        expect(response.body).toBe("[{\"author\":\"john_doe\",\"name\":\"cest\"}]");
     });
 });

--- a/tests/integration/test_bits.cpp
+++ b/tests/integration/test_bits.cpp
@@ -144,4 +144,28 @@ describe("CPM Hub bits management", []() {
         expect(response.status_code).toBe(HttpStatus::OK);
         expect(response.body).toBe("{\"bit_name\":\"cest\",\"payload\":\"ABCDEabcde\",\"version\":\"1.0\"}");
     });
+
+    it("searches bits whose name contains given text and returns found bits metadata", [&]() {
+        HttpRequest publish_request("{"
+                                    "\"bit_name\": \"cest\","
+                                    "\"version\": \"1.0\","
+                                    "\"payload\": \"ABCDEabcde\","
+                                    "\"username\": \"john_doe\","
+                                    "\"password\": \"12345\""
+                                    "}");
+        HttpRequest search_request;
+        HttpResponse response;
+        BitsRepositoryInMemory repository;
+        BitsService service(&repository);
+        BitsHttpResource api(&service);
+
+        // Given
+        api.post(publish_request);
+        search_request.query_parameters.set("name", "cest");
+
+        response = api.get(search_request);
+
+        expect(response.status_code).toBe(HttpStatus::OK);
+        expect(response.body).toBe("[{\"name\":\"cest\",\"author\":\"john_doe\"}]");
+    });
 });

--- a/tests/unit/bits/test_bit_index.cpp
+++ b/tests/unit/bits/test_bit_index.cpp
@@ -89,4 +89,28 @@ describe("Bits Repository in file system", []() {
         expect(bit_index.find("cest").value()).toBe("user/cest/1.0");
         expect(bit_index.find("fakeit").value()).toBe("user/fakeit/3.1");
     });
+
+    it("returns zero bits when search has no matches", [&]() {
+        BitIndex bit_index;
+        std::list<BitIndexEntry> search_results;
+        BitSearchQuery search_query{"name"};
+
+        bit_index.indexBit("cest", std::string(), "user/cest/1.0");
+
+        search_results = bit_index.search(search_query);
+
+        expect(search_results.size()).toBe(0);
+    });
+
+    it("returns search with one result when searching for bits based on name and one matches", [&]() {
+        BitIndex bit_index;
+        std::list<BitIndexEntry> search_results;
+        BitSearchQuery search_query{"cest"};
+
+        bit_index.indexBit("cest", std::string(), "user/cest/1.0");
+
+        search_results = bit_index.search(search_query);
+
+        expect(search_results.size()).toBe(1);
+    });
 });

--- a/tests/unit/bits/test_bits_http_resource.cpp
+++ b/tests/unit/bits/test_bits_http_resource.cpp
@@ -183,4 +183,27 @@ describe("Bits API", []() {
         }));
         expect(response.body).toBe("[{\"author\":\"pepe\",\"name\":\"cest\"}]");
     });
+
+    it("returns bad request when search query does not contain 'name' parameter", [&]() {
+        HttpRequest request;
+        HttpResponse response;
+        Mock<BitsService> mock_service;
+        BitsHttpResource api(&mock_service.get());
+
+        response = api.get(request);
+
+        expect(response.status_code).toBe(HttpStatus::BAD_REQUEST);
+    });
+
+    it("returns bad request when 'name' parameter in search query is empty", [&]() {
+        HttpRequest request;
+        HttpResponse response;
+        Mock<BitsService> mock_service;
+        BitsHttpResource api(&mock_service.get());
+
+        request.query_parameters.set("name", "");
+        response = api.get(request);
+
+        expect(response.status_code).toBe(HttpStatus::BAD_REQUEST);
+    });
 });

--- a/tests/unit/bits/test_bits_repository_in_filesystem.cpp
+++ b/tests/unit/bits/test_bits_repository_in_filesystem.cpp
@@ -224,6 +224,7 @@ describe("Bits Repository in file system", []() {
         When(Method(mock_filesystem, writeFile)).AlwaysReturn();
         When(Method(mock_filesystem, readFile))
                 .Return("{\"name\":\"cest\",\"user_name\":\"user\",\"version\":\"1.1\"}");
+        When(Method(mock_filesystem, listDirectories)).Return(list<string>{"1.0"});
 
         repository.add(cest_bit);
 

--- a/tests/unit/bits/test_bits_repository_in_filesystem.cpp
+++ b/tests/unit/bits/test_bits_repository_in_filesystem.cpp
@@ -80,7 +80,7 @@ describe("Bits Repository in file system", []() {
         BitsRepositoryInFilesystem repository(&mock_filesystem.get(), &bit_index);
         Optional<Bit> bit;
 
-        bit = repository.find("cest");
+        bit = repository.bitBy("cest");
 
         expect(bit.isPresent()).toBe(false);
     });
@@ -101,7 +101,7 @@ describe("Bits Repository in file system", []() {
 
         repository.add(cest_bit);
 
-        bit = repository.find("cest");
+        bit = repository.bitBy("cest");
 
         expect(bit.isPresent()).toBe(true);
         expect(bit.value().metadata.name).toBe("cest");
@@ -137,7 +137,7 @@ describe("Bits Repository in file system", []() {
         When(Method(mock_filesystem, listDirectories)).Return(list<string>{"1.0"});
 
         repository.restore(".");
-        bit = repository.find("cest");
+        bit = repository.bitBy("cest");
 
         expect(bit.value().metadata.name).toBe("cest");
         expect(bit.value().metadata.version).toBe("1.0");
@@ -159,7 +159,7 @@ describe("Bits Repository in file system", []() {
         When(Method(mock_filesystem, listDirectories)).Return(list<string>{"1.0"});
 
         repository.restore(".");
-        bit = repository.find("cest");
+        bit = repository.bitBy("cest");
 
         expect(bit.value().metadata.name).toBe("cest");
         expect(bit.value().metadata.version).toBe("1.0");
@@ -183,7 +183,7 @@ describe("Bits Repository in file system", []() {
 
         repository.add(cest_bit);
 
-        bit = repository.find("cest", "1.1");
+        bit = repository.bitBy("cest", "1.1");
 
         Verify(Method(mock_filesystem, directoryExists).Using("./user/cest/1.1"));
         expect(bit.isPresent()).toBe(true);
@@ -206,7 +206,7 @@ describe("Bits Repository in file system", []() {
 
         repository.add(cest_bit);
 
-        bit = repository.find("cest", "1.0");
+        bit = repository.bitBy("cest", "1.0");
 
         Verify(Method(mock_filesystem, directoryExists).Using("./user/cest/1.0"));
         expect(bit.isPresent()).toBe(false);

--- a/tests/unit/bits/test_bits_repository_in_filesystem.cpp
+++ b/tests/unit/bits/test_bits_repository_in_filesystem.cpp
@@ -211,4 +211,25 @@ describe("Bits Repository in file system", []() {
         Verify(Method(mock_filesystem, directoryExists).Using("./user/cest/1.0"));
         expect(bit.isPresent()).toBe(false);
     });
+
+    it("returns search results with one bit when search matches", [&]() {
+        Mock<Filesystem> mock_filesystem;
+        BitIndex bit_index;
+        BitsRepositoryInFilesystem repository(&mock_filesystem.get(), &bit_index);
+        Bit cest_bit("cest", "1.1", "user", "Yml0IHBheWxvYWQ=");
+        list<BitMetadata> search_results;
+
+        When(Method(mock_filesystem, createDirectory)).AlwaysReturn();
+        When(Method(mock_filesystem, directoryExists)).Return(true);
+        When(Method(mock_filesystem, writeFile)).AlwaysReturn();
+        When(Method(mock_filesystem, readFile))
+                .Return("{\"name\":\"cest\",\"user_name\":\"user\",\"version\":\"1.1\"}");
+
+        repository.add(cest_bit);
+
+        search_results = repository.search(BitSearchQuery{"cest"});
+
+        expect(search_results.size()).toBe(1);
+        expect(search_results.front().name).toBe("cest");
+    });
 });

--- a/tests/unit/bits/test_bits_repository_in_memory.cpp
+++ b/tests/unit/bits/test_bits_repository_in_memory.cpp
@@ -46,7 +46,7 @@ describe("Bits Repository in Memory", []() {
         BitsRepositoryInMemory repository;
         Optional<Bit> bit;
 
-        bit = repository.find("cest");
+        bit = repository.bitBy("cest");
 
         expect(bit.isPresent()).toBe(false);
     });
@@ -58,7 +58,7 @@ describe("Bits Repository in Memory", []() {
 
         repository.add(bit);
 
-        stored_bit = repository.find("cest");
+        stored_bit = repository.bitBy("cest");
 
         expect(stored_bit.value().metadata.name).toBe(bit.metadata.name);
     });
@@ -71,7 +71,7 @@ describe("Bits Repository in Memory", []() {
         repository.add(cest_bit);
         repository.add(fakeit_bit);
 
-        stored_bit = repository.find("fakeit");
+        stored_bit = repository.bitBy("fakeit");
 
         expect(stored_bit.value().metadata.name).toBe(fakeit_bit.metadata.name);
     });
@@ -84,12 +84,12 @@ describe("Bits Repository in Memory", []() {
         cest_bit.metadata.version = "1.0";
         repository.add(cest_bit);
 
-        stored_bit = repository.find("cest", "1.1");
+        stored_bit = repository.bitBy("cest", "1.1");
 
         expect(stored_bit.isPresent()).toBe(false);
     });
 
-    it("finds a bit given version when it's stored", [&]() {
+    it("gets a bit given version when it's stored", [&]() {
         BitsRepositoryInMemory repository;
         Bit cest_bit_1_0("cest");
         Bit cest_bit_1_1("cest");
@@ -100,13 +100,13 @@ describe("Bits Repository in Memory", []() {
         cest_bit_1_0.metadata.version = "1.0";
         repository.add(cest_bit_1_0);
 
-        stored_bit = repository.find("cest", "1.1");
+        stored_bit = repository.bitBy("cest", "1.1");
 
         expect(stored_bit.isPresent()).toBe(true);
         expect(stored_bit.value().metadata.version).toBe("1.1");
     });
 
-    it("finds the latest version of a bit when many are stored but version is not specified", [&]() {
+    it("gets the latest version of a bit when many are stored but version is not specified", [&]() {
         BitsRepositoryInMemory repository;
         Bit cest_bit_1_0("cest");
         Bit cest_bit_1_1("cest");
@@ -117,9 +117,31 @@ describe("Bits Repository in Memory", []() {
         cest_bit_1_0.metadata.version = "1.0";
         repository.add(cest_bit_1_0);
 
-        stored_bit = repository.find("cest");
+        stored_bit = repository.bitBy("cest");
 
         expect(stored_bit.isPresent()).toBe(true);
         expect(stored_bit.value().metadata.version).toBe("1.1");
+    });
+
+    it("returns empty list when searching for bits and repository is empty", []() {
+        BitsRepositoryInMemory repository;
+        BitSearchQuery search_query;
+
+        expect(repository.search(search_query).size()).toBe(0);
+    });
+
+    it("returns list with bit found when searching for bits and repository contains one matching bit", []() {
+        BitsRepositoryInMemory repository;
+        Bit cest_bit("cest");
+        BitSearchQuery search_query;
+        std::list<BitMetadata> found_bits;
+
+        search_query.name = "cest";
+        repository.add(cest_bit);
+
+        found_bits = repository.search(search_query);
+
+        expect(found_bits.size()).toBe(1);
+        expect(found_bits.front().name).toBe("cest");
     });
 });

--- a/tests/unit/bits/test_bits_service.cpp
+++ b/tests/unit/bits/test_bits_service.cpp
@@ -63,9 +63,9 @@ describe("Bits Service", []() {
         Optional<Bit> bit;
 
         bit = Bit("cest");
-        When(OverloadedMethod(mock_repository, find, Optional<Bit>(string))).Return(bit);
+        When(OverloadedMethod(mock_repository, bitBy, Optional<Bit>(string))).Return(bit);
 
-        auto found_bit = bits_service.find("cest");
+        auto found_bit = bits_service.bitBy("cest");
 
         expect(found_bit.value().metadata.name).toBe("cest");
     });
@@ -76,9 +76,9 @@ describe("Bits Service", []() {
         Optional<Bit> bit;
 
         bit = Bit("cest");
-        When(OverloadedMethod(mock_repository, find, Optional<Bit>(string, string))).Return(bit);
+        When(OverloadedMethod(mock_repository, bitBy, Optional<Bit>(string, string))).Return(bit);
 
-        auto found_bit = bits_service.find("cest", "1.1");
+        auto found_bit = bits_service.bitBy("cest", "1.1");
 
         expect(found_bit.value().metadata.name).toBe("cest");
     });

--- a/tests/unit/bits/test_bits_service.cpp
+++ b/tests/unit/bits/test_bits_service.cpp
@@ -82,4 +82,19 @@ describe("Bits Service", []() {
 
         expect(found_bit.value().metadata.name).toBe("cest");
     });
+
+    it("uses the repository to search for a bit by name", [&]() {
+        Mock<BitsRepository> mock_repository;
+        BitsService bits_service(&mock_repository.get());
+        Bit bit("cest");
+        std::list<BitMetadata> search_results {bit.metadata};
+        BitSearchQuery search_query{"cest"};
+
+        When(Method(mock_repository, search)).Return(search_results);
+
+        search_results = bits_service.search(search_query);
+
+        expect(search_results.size()).toBe(1);
+        expect(search_results.front().name).toBe("cest");
+    });
 });


### PR DESCRIPTION
The `/bits` endpoint has been extended so that when no bit is specified and the `name` query parameter is used, `cpm-hub` will perform a search over the existing bits:

```
http://cpmhub:8000/bits?name=cest
```

The above will return in the search results all bits whose name contain the string `cest`.