### PR TITLE
fix HttpClient connection close

### DIFF
--- a/cpm-hub/http/HttpClient.h
+++ b/cpm-hub/http/HttpClient.h
@@ -29,6 +29,7 @@ public:
     virtual HttpResponse put(std::string url, HttpRequest request);
     virtual HttpResponse method(std::string url, HttpRequest request, std::string method);
     virtual void responseArrived(HttpResponse response);
+    virtual void connectionClosed();
 
 private:
     bool request_pending;


### PR DESCRIPTION
HttpClient was not handling properly the events reported by mongoose. This pull request fixes that so that connections are properly closed.