### PR TITLE
Migrate AccessFileAuthenticator unit tests to cpputest

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -21,7 +21,7 @@ jobs:
           pip3 install --upgrade cpm-cli
           pip3 install pyyaml
           pip3 install requests
-          sudo apt install -yq ninja-build g++ libboost-all-dev
+          sudo apt install -yq ninja-build g++ libboost-all-dev cpputest
           cpm install
       - name: Test with CPM
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ jobs:
           pip3 install --upgrade cpm-cli
           pip3 install pyyaml
           pip3 install requests
-          sudo apt install -yq ninja-build g++ libboost-all-dev
+          sudo apt install -yq ninja-build g++ libboost-all-dev cpputest
           cpm install
       - name: Test with CPM
         run: |

--- a/cpm-hub/bits/rest_api/BitsHttpResource.cpp
+++ b/cpm-hub/bits/rest_api/BitsHttpResource.cpp
@@ -66,6 +66,16 @@ HttpResponse BitsHttpResource::post(HttpRequest &request)
 }
 
 
+HttpResponse BitsHttpResource::get(HttpRequest &request)
+{
+    if (!request.parameters.has("bitName")) {
+        return searchForBit(request);
+    } else {
+        return getBit(request);
+    }
+}
+
+
 HttpResponse BitsHttpResource::listBits(HttpRequest &request)
 {
     HttpResponse response;
@@ -77,16 +87,6 @@ HttpResponse BitsHttpResource::listBits(HttpRequest &request)
     }
 
     return HttpResponse::ok(json_bits.dump());
-}
-
-
-HttpResponse BitsHttpResource::get(HttpRequest &request)
-{
-    if (!request.parameters.has("bitName")) {
-        return searchForBit(request);
-    } else {
-        return getBit(request);
-    }
 }
 
 

--- a/cpm-hub/kpi/KpiSinkInfluxDb.cpp
+++ b/cpm-hub/kpi/KpiSinkInfluxDb.cpp
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// curl -i -XPOST 'http://localhost:8086/write?db=mydb' --data-binary "cpu_load_short,host=server01,region=us-west value=0.1 $(date '+%s%N')"
 #include <sstream>
 #include <kpi/KpiSinkInfluxDb.h>
 #include <http/HttpClient.h>
@@ -31,7 +30,7 @@ KpiSinkInfluxDb::KpiSinkInfluxDb(string influxdb_url, string database)
 }
 
 
-void KpiSinkInfluxDb::newMeasure(string kpi, double value, map <string, string> tags, chrono::nanoseconds time)
+void KpiSinkInfluxDb::newMeasure(string kpi, double value, map<string, string> tags, chrono::nanoseconds time)
 {
     HttpClient client;
     HttpRequest request(this->formatMessage(move(kpi), value, move(tags), time));

--- a/project.yaml
+++ b/project.yaml
@@ -19,9 +19,14 @@ bits:
     inih: '1.0'
     spdlog: '1.6.1'
     sqlite3: '3.32.3'
-test_bits:
-    fakeit: '2.0.5'
-    cest: '1.0'
+test:
+    packages:
+        tests/mocks:
+    bits:
+        fakeit: '2.0.5'
+        cest: '1.0'
+    link_options:
+        libraries: ['CppUTest', 'CppUTestExt']
 link_options:
     libraries: ['boost_filesystem', 'boost_system', 'boost_program_options', 'pthread', 'ssl', 'crypto']
 actions:

--- a/tests/mocks/MockFilesystem.h
+++ b/tests/mocks/MockFilesystem.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020  Jordi Sánchez
+ * This file is part of CPM Hub
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+
+#include <infrastructure/Filesystem.h>
+
+
+class MockFilesystem: public Filesystem {
+public:
+    void writeFile(std::string file_name, std::string contents) {
+        mock().actualCall("Filesystem.writeFile");
+    }
+
+    std::string readFile(std::string file_name) {
+        return mock().actualCall("Filesystem.readFile")
+                     .withParameter("file_name", file_name.c_str())
+                     .returnStringValue();
+    }
+
+    void createDirectory(std::string path) {
+        mock().actualCall("Filesystem.createDirectory");
+    }
+
+    std::list<std::string> listDirectories(std::string path) {
+        mock().actualCall("Filesystem.listDirectories");
+        return std::list<std::string>();
+    }
+
+    bool fileExists(std::string file_name) {
+        mock().actualCall("Filesystem.fileExists");
+        return false;
+    }
+
+    bool directoryExists(std::string path) {
+        mock().actualCall("Filesystem.directoryExists");
+        return false;
+    }
+
+    void deleteFile(std::string file_name) {
+        mock().actualCall("Filesystem.deleteFile");
+    }
+
+    void changePermissions(std::string file_name, unsigned int mask) {
+        mock().actualCall("Filesystem.changePermissions");
+    }
+
+    MockExpectedCall &expect(const std::string& call) {
+        std::string full_call = std::string("Filesystem.") + call;
+        return mock().expectOneCall(full_call.c_str());
+    }
+};

--- a/tests/mocks/cpputest.h
+++ b/tests/mocks/cpputest.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020  Jordi Sánchez
+ * This file is part of CPM Hub
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "CppUTest/CommandLineTestRunner.h"
+#include "CppUTest/TestHarness.h"
+#include "CppUTestExt/MockSupport.h"
+
+
+#define ASSERT_TRUE(condition)                  CHECK(condition)
+#define ASSERT_FALSE(condition)                 CHECK_FALSE(condition)
+#define ASSERT_STRING_EQUALS(expected, actual)  STRCMP_EQUAL(std::string(expected).c_str(), std::string(actual).c_str())
+
+
+#define TEST_WITH_MOCK(testGroup, testName) \
+  class TEST_##testGroup##_##testName##_TestShell; \
+  extern TEST_##testGroup##_##testName##_TestShell TEST_##testGroup##_##testName##_TestShell_instance; \
+  \
+  class TEST_##testGroup##_##testName##_Test : public TEST_GROUP_##CppUTestGroup##testGroup { \
+public: TEST_##testGroup##_##testName##_Test () : TEST_GROUP_##CppUTestGroup##testGroup () {} \
+       void testBodyWrapped(); \
+       void testBody(); \
+}; \
+  class TEST_##testGroup##_##testName##_TestShell : public UtestShell { \
+      virtual Utest* createTest() _override { return new TEST_##testGroup##_##testName##_Test; } \
+  } TEST_##testGroup##_##testName##_TestShell_instance; \
+  static TestInstaller TEST_##testGroup##_##testName##_Installer(TEST_##testGroup##_##testName##_TestShell_instance, #testGroup, #testName, __FILE__,__LINE__); \
+    void TEST_##testGroup##_##testName##_Test::testBody() { testBodyWrapped(); mock().checkExpectations(); mock().clear(); } \
+    void TEST_##testGroup##_##testName##_Test::testBodyWrapped()
+
+
+int main(int ac, char** av)
+{
+    return CommandLineTestRunner::RunAllTests(ac, av);
+}


### PR DESCRIPTION
First step towards migration to CppUTest, a more mature testing framework with support for test debugging and easier to use mocks.