### PR TITLE
Migrate CpmHubAuthenticator to cpputest

### DIFF
--- a/cpm-hub/authentication/CpmHubAuthenticator.cpp
+++ b/cpm-hub/authentication/CpmHubAuthenticator.cpp
@@ -25,7 +25,7 @@ using namespace nlohmann;
 constexpr char hexmap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
 
-CpmHubAuthenticator::CpmHubAuthenticator(string &auth_service_url, HttpClient &client)
+CpmHubAuthenticator::CpmHubAuthenticator(const string &auth_service_url, HttpClient &client)
 {
     this->authentication_endpoint = auth_service_url + "/auth";
     this->users_endpoint = auth_service_url + "/users";

--- a/cpm-hub/authentication/CpmHubAuthenticator.h
+++ b/cpm-hub/authentication/CpmHubAuthenticator.h
@@ -25,7 +25,7 @@
 class CpmHubAuthenticator : public Authenticator {
 
 public:
-    CpmHubAuthenticator(std::string &auth_service_url, HttpClient &client);
+    CpmHubAuthenticator(const std::string &auth_service_url, HttpClient &client);
 
     virtual Optional<std::string> authenticate(const char *key) override;
 

--- a/cpm-hub/http/HttpRequest.h
+++ b/cpm-hub/http/HttpRequest.h
@@ -34,4 +34,8 @@ struct HttpRequest {
     HttpRequest(std::string _body="") {
         body = _body;
     }
+
+    void withHeader(const std::string &name, const std::string &value) {
+        headers.set(name, value);
+    }
 };

--- a/tests/mocks/MockHttpClient.h
+++ b/tests/mocks/MockHttpClient.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020  Jordi Sánchez
+ * This file is part of CPM Hub
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <http/HttpClient.h>
+
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+
+
+class MockHttpClient: public HttpClient {
+public:
+    HttpResponse get(std::string url, HttpRequest request) {
+        last_request = request;
+        return *(HttpResponse *)mock().actualCall("HttpClient.get")
+                                      .withParameter("url", url.c_str())
+                                      .returnPointerValue();
+    }
+    
+    HttpResponse post(std::string url, HttpRequest request) {
+        last_request = request;
+        return *(HttpResponse *)mock().actualCall("HttpClient.post")
+                .withParameter("url", url.c_str())
+                .returnPointerValue();
+    }
+
+    HttpResponse put(std::string url, HttpRequest request) {
+        last_request = request;
+        return *(HttpResponse *)mock().actualCall("HttpClient.put")
+                .withParameter("url", url.c_str())
+                .returnPointerValue();
+    }
+
+    HttpResponse method(std::string url, HttpRequest request, std::string method) {
+        last_request = request;
+        return *(HttpResponse *)mock().actualCall("HttpClient.method")
+                .withParameter("url", url.c_str())
+                .withParameter("method", method.c_str())
+                .returnPointerValue();
+    }
+
+    void responseArrived(HttpResponse response) {
+    }
+
+    void connectionClosed() {
+    }
+
+    MockExpectedCall &expect(const std::string& call) {
+        std::string full_call = std::string("HttpClient.") + call;
+        return mock().expectOneCall(full_call.c_str());
+    }
+
+    HttpRequest last_request;
+};

--- a/tests/mocks/cpputest.h
+++ b/tests/mocks/cpputest.h
@@ -22,9 +22,10 @@
 #include "CppUTestExt/MockSupport.h"
 
 
-#define ASSERT_TRUE(condition)                  CHECK(condition)
-#define ASSERT_FALSE(condition)                 CHECK_FALSE(condition)
-#define ASSERT_STRING_EQUALS(expected, actual)  STRCMP_EQUAL(std::string(expected).c_str(), std::string(actual).c_str())
+#define ASSERT_TRUE(condition)                          CHECK(condition)
+#define ASSERT_FALSE(condition)                         CHECK_FALSE(condition)
+#define ASSERT_STRING_EQUALS(expected, actual)          STRCMP_EQUAL(std::string(expected).c_str(), std::string(actual).c_str())
+#define ASSERT_THROWS(expected_exception, expression)   CHECK_THROWS(expected_exception, expression)
 
 
 #define TEST_WITH_MOCK(testGroup, testName) \

--- a/tests/unit/authentication/test_access_file_authenticator.cpp
+++ b/tests/unit/authentication/test_access_file_authenticator.cpp
@@ -23,7 +23,8 @@
 using namespace std;
 
 
-TEST_GROUP(AccessFileAuthenticator) {
+TEST_GROUP(AccessFileAuthenticator)
+{
     void teardown()
     {
         mock().clear();

--- a/tests/unit/authentication/test_cpm_hub_authenticator.cpp
+++ b/tests/unit/authentication/test_cpm_hub_authenticator.cpp
@@ -15,104 +15,113 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <cest/cest.h>
-#include <fakeit/fakeit.hpp>
+#include <mocks/MockHttpClient.h>
+#include <mocks/cpputest.h>
 
 #include <authentication/CpmHubAuthenticator.h>
 
-using namespace cest;
-using namespace fakeit;
 using namespace std;
 
 
-describe("CpmHubAuthenticator", []() {
-    it("Fails to authenticate when cpm hub auth service is down", []() {
-        Mock<HttpClient> mock_http_client;
-        string auth_service_url("http://localhost:1234");
-        CpmHubAuthenticator authenticator(auth_service_url, mock_http_client.get());
-        UserCredentials credentials = {"user", "pass"};
+TEST_GROUP(CpmHubAuthenticator)
+{
+};
 
-        When(Method(mock_http_client, post)).Return(HttpResponse::notFound());
 
-        expect(authenticator.validCredentials(credentials)).toBe(false);
-    });
+TEST_WITH_MOCK(CpmHubAuthenticator, fails_to_authenticate_when_cpm_hub_auth_service_is_down)
+{
+    MockHttpClient http_client;
+    CpmHubAuthenticator authenticator("http://localhost:1234", http_client);
+    UserCredentials credentials = {"user", "pass"};
+    HttpResponse not_found = HttpResponse::notFound();
 
-    it("Fails to authenticate when not authorized", []() {
-        Mock<HttpClient> mock_http_client;
-        string auth_service_url("http://localhost:1234");
-        CpmHubAuthenticator authenticator(auth_service_url, mock_http_client.get());
-        UserCredentials credentials = {"user", "pass"};
+    http_client.expect("post")
+               .withParameter("url", "http://localhost:1234/auth")
+               .ignoreOtherParameters()
+               .andReturnValue(&not_found);
 
-        When(Method(mock_http_client, post)).Return(HttpResponse::unauthorized());
+    ASSERT_FALSE(authenticator.validCredentials(credentials));
+}
 
-        expect(authenticator.validCredentials(credentials)).toBe(false);
-    });
 
-    it("Confirms valid credentials when authorized", []() {
-        Mock<HttpClient> mock_http_client;
-        string auth_service_url("http://localhost:1234");
-        CpmHubAuthenticator authenticator(auth_service_url, mock_http_client.get());
-        UserCredentials credentials = {"user", "pass"};
+TEST_WITH_MOCK(CpmHubAuthenticator, fails_to_authenticate_when_not_authorized)
+{
+    MockHttpClient http_client;
+    CpmHubAuthenticator authenticator("http://localhost:1234", http_client);
+    UserCredentials credentials = {"user", "pass"};
+    HttpResponse unauthorized = HttpResponse::unauthorized();
 
-        When(Method(mock_http_client, post)).Return(HttpResponse::ok(""));
+    http_client.expect("post")
+               .withParameter("url", "http://localhost:1234/auth")
+               .ignoreOtherParameters()
+               .andReturnValue(&unauthorized);
 
-        expect(authenticator.validCredentials(credentials)).toBe(true);
+    ASSERT_FALSE(authenticator.validCredentials(credentials));
+}
 
-        Verify(Method(mock_http_client, post).Matching([](string url, HttpRequest request) {
-            return url == "http://localhost:1234/auth" &&
-                   request.body == "{\"password\":\"7be1b497736a4478f45a07661468dd282edc01d31a403641dd3e2a07cac4fc05\",\"username\":\"user\"}" &&
-                   request.headers.get("Content-type") == "application/json";
-        }));
-    });
 
-    it("Sends request to authentication service when adding user", []() {
-        Mock<HttpClient> mock_http_client;
-        string auth_service_url("http://localhost:1234");
-        CpmHubAuthenticator authenticator(auth_service_url, mock_http_client.get());
-        UserCredentials credentials = {"user", "pass"};
+TEST_WITH_MOCK(CpmHubAuthenticator, confirms_valid_credentials_when_authorized)
+{
+    MockHttpClient http_client;
+    CpmHubAuthenticator authenticator("http://localhost:1234", http_client);
+    UserCredentials credentials = {"user", "pass"};
+    HttpRequest request = HttpRequest("{\"password\":\"7be1b497736a4478f45a07661468dd282edc01d31a403641dd3e2a07cac4fc05\",\"username\":\"user\"}");
+    HttpResponse ok = HttpResponse::ok("");
 
-        When(Method(mock_http_client, post)).Return(HttpResponse::ok(""));
+    http_client.expect("post")
+               .withParameter("url", "http://localhost:1234/auth")
+               .andReturnValue(&ok);
 
-        authenticator.addUser(credentials);
+    ASSERT_TRUE(authenticator.validCredentials(credentials));
+}
 
-        Verify(Method(mock_http_client, post).Matching([](string url, HttpRequest request) {
-            return url == "http://localhost:1234/users" &&
-                   request.body == "{\"password\":\"7be1b497736a4478f45a07661468dd282edc01d31a403641dd3e2a07cac4fc05\",\"username\":\"user\"}" &&
-                   request.headers.get("Content-type") == "application/json";
-        }));
-    });
 
-    it("Sends request to authentication service when adding user by invitation", []() {
-        Mock<HttpClient> mock_http_client;
-        string auth_service_url("http://localhost:1234");
-        CpmHubAuthenticator authenticator(auth_service_url, mock_http_client.get());
-        UserCredentials credentials = {"user", "pass"};
+TEST_WITH_MOCK(CpmHubAuthenticator, sends_request_to_authentication_service_when_adding_user)
+{
+    MockHttpClient http_client;
+    CpmHubAuthenticator authenticator("http://localhost:1234", http_client);
+    UserCredentials credentials = {"user", "pass"};
+    HttpRequest request = HttpRequest("{\"password\":\"7be1b497736a4478f45a07661468dd282edc01d31a403641dd3e2a07cac4fc05\",\"username\":\"user\"}");
+    HttpResponse ok = HttpResponse::ok("");
 
-        When(Method(mock_http_client, post)).Return(HttpResponse::ok(""));
+    http_client.expect("post")
+               .withParameter("url", "http://localhost:1234/users")
+               .andReturnValue(&ok);
 
-        authenticator.addUserWithInvitation(credentials, "invitation_token");
+    authenticator.addUser(credentials);
+}
 
-        Verify(Method(mock_http_client, post).Matching([](string url, HttpRequest request) {
-            return url == "http://localhost:1234/users" &&
-                   request.body == "{\"password\":\"7be1b497736a4478f45a07661468dd282edc01d31a403641dd3e2a07cac4fc05\",\"username\":\"user\"}" &&
-                   request.headers.get("Content-type") == "application/json" &&
-                   request.headers.get("OTP") == "invitation_token";
-        }));
-    });
 
-    it("throws an invalid invitation token exception when receiving unauthorized response", []() {
-        Mock<HttpClient> mock_http_client;
-        string auth_service_url("http://localhost:1234");
-        CpmHubAuthenticator authenticator(auth_service_url, mock_http_client.get());
-        UserCredentials credentials = {"user", "pass"};
+TEST_WITH_MOCK(CpmHubAuthenticator, sends_request_to_authentication_service_when_adding_user_by_invitation)
+{
+    MockHttpClient http_client;
+    CpmHubAuthenticator authenticator("http://localhost:1234", http_client);
+    UserCredentials credentials = {"user", "pass"};
+    HttpResponse ok = HttpResponse::ok("");
 
-        When(Method(mock_http_client, post)).Return(HttpResponse::unauthorized());
+    http_client.expect("post")
+               .withParameter("url", "http://localhost:1234/users")
+               .andReturnValue(&ok);
 
-        try {
-            authenticator.addUserWithInvitation(credentials, "invitation_token");
-            failTest();
-        } catch(InvalidInvitationToken&) {
-            passTest();
-        }
-    });
-});
+    authenticator.addUserWithInvitation(credentials, "invitation_token");
+
+    ASSERT_STRING_EQUALS(http_client.last_request.body, "{\"password\":\"7be1b497736a4478f45a07661468dd282edc01d31a403641dd3e2a07cac4fc05\",\"username\":\"user\"}");
+    ASSERT_STRING_EQUALS(http_client.last_request.headers.get("Content-type"), "application/json");
+    ASSERT_STRING_EQUALS(http_client.last_request.headers.get("OTP"), "invitation_token");
+}
+
+
+
+TEST_WITH_MOCK(CpmHubAuthenticator, throws_an_invalid_invitation_token_exception_when_receiving_unauthorized_response)
+{
+    MockHttpClient http_client;
+    CpmHubAuthenticator authenticator("http://localhost:1234", http_client);
+    UserCredentials credentials = {"user", "pass"};
+    HttpResponse ok = HttpResponse::unauthorized();
+
+    http_client.expect("post")
+            .withParameter("url", "http://localhost:1234/users")
+            .andReturnValue(&ok);
+
+    ASSERT_THROWS(InvalidInvitationToken, authenticator.addUserWithInvitation(credentials, "invitation_token"));
+}


### PR DESCRIPTION
Continue migrating to CppUTest: `CpmHubAuthenticator`.