### PR TITLE
migrate BitIndex to CppUTest

### DIFF
--- a/cpm-hub/bits/BitIndex.cpp
+++ b/cpm-hub/bits/BitIndex.cpp
@@ -106,3 +106,15 @@ list<BitIndexEntry> BitIndex::search(BitSearchQuery search_query)
 
     return found_bits;
 }
+
+
+std::list<BitIndexEntry> BitIndex::allIndexedBits()
+{
+    std::list<BitIndexEntry> all_indexed_bits;
+
+    for (auto &bit_map: this->bits) {
+        all_indexed_bits.push_back(bit_map.second);
+    }
+
+    return all_indexed_bits;
+}

--- a/cpm-hub/bits/BitIndex.h
+++ b/cpm-hub/bits/BitIndex.h
@@ -46,6 +46,8 @@ public:
 
     virtual std::list<BitIndexEntry> search(BitSearchQuery search_query);
 
+    virtual std::list<BitIndexEntry> allIndexedBits();
+
 private:
     const std::string index_version = "1";
     Filesystem *filesystem;

--- a/tests/mocks/cpputest.h
+++ b/tests/mocks/cpputest.h
@@ -24,7 +24,8 @@
 
 #define ASSERT_TRUE(condition)                          CHECK(condition)
 #define ASSERT_FALSE(condition)                         CHECK_FALSE(condition)
-#define ASSERT_STRING_EQUALS(expected, actual)          STRCMP_EQUAL(std::string(expected).c_str(), std::string(actual).c_str())
+#define ASSERT_EQUAL(expected, actual)                  CHECK_EQUAL(expected, actual)
+#define ASSERT_STRING(expected, actual)                 STRCMP_EQUAL(std::string(expected).c_str(), std::string(actual).c_str())
 #define ASSERT_THROWS(expected_exception, expression)   CHECK_THROWS(expected_exception, expression)
 
 

--- a/tests/unit/authentication/test_access_file_authenticator.cpp
+++ b/tests/unit/authentication/test_access_file_authenticator.cpp
@@ -90,7 +90,7 @@ TEST_WITH_MOCK(AccessFileAuthenticator, returns_username_when_authenticating_api
     username = access_file_authenticator.authenticate("one_api_key");
 
     ASSERT_TRUE(username.isPresent());
-    ASSERT_STRING_EQUALS("username", username.value());
+    ASSERT_STRING("username", username.value());
 }
 
 
@@ -108,7 +108,7 @@ TEST_WITH_MOCK(AccessFileAuthenticator, returns_username_when_authenticating_api
     username = access_file_authenticator.authenticate("one_api_key");
 
     ASSERT_TRUE(username.isPresent());
-    ASSERT_STRING_EQUALS("username", username.value());
+    ASSERT_STRING("username", username.value());
 }
 
 
@@ -127,7 +127,7 @@ TEST_WITH_MOCK(AccessFileAuthenticator, returns_username_when_authenticating_api
     username = access_file_authenticator.authenticate("alice_api_key");
 
     ASSERT_TRUE(username.isPresent());
-    ASSERT_STRING_EQUALS("alice", username.value());
+    ASSERT_STRING("alice", username.value());
 }
 
 

--- a/tests/unit/authentication/test_cpm_hub_authenticator.cpp
+++ b/tests/unit/authentication/test_cpm_hub_authenticator.cpp
@@ -105,9 +105,9 @@ TEST_WITH_MOCK(CpmHubAuthenticator, sends_request_to_authentication_service_when
 
     authenticator.addUserWithInvitation(credentials, "invitation_token");
 
-    ASSERT_STRING_EQUALS(http_client.last_request.body, "{\"password\":\"7be1b497736a4478f45a07661468dd282edc01d31a403641dd3e2a07cac4fc05\",\"username\":\"user\"}");
-    ASSERT_STRING_EQUALS(http_client.last_request.headers.get("Content-type"), "application/json");
-    ASSERT_STRING_EQUALS(http_client.last_request.headers.get("OTP"), "invitation_token");
+    ASSERT_STRING(http_client.last_request.body, "{\"password\":\"7be1b497736a4478f45a07661468dd282edc01d31a403641dd3e2a07cac4fc05\",\"username\":\"user\"}");
+    ASSERT_STRING(http_client.last_request.headers.get("Content-type"), "application/json");
+    ASSERT_STRING(http_client.last_request.headers.get("OTP"), "invitation_token");
 }
 
 


### PR DESCRIPTION
Migrating `BitIndex` class to CppUTest. Also includes a new funcion `allIndexedBits` to get all indexed bits from the index.