### PR TITLE
Implemented allBits method for BitRepositoryInFilesystem

### DIFF
--- a/cpm-hub/bits/BitIndex.cpp
+++ b/cpm-hub/bits/BitIndex.cpp
@@ -108,9 +108,9 @@ list<BitIndexEntry> BitIndex::search(BitSearchQuery search_query)
 }
 
 
-std::list<BitIndexEntry> BitIndex::allIndexedBits()
+list<BitIndexEntry> BitIndex::allIndexedBits()
 {
-    std::list<BitIndexEntry> all_indexed_bits;
+    list<BitIndexEntry> all_indexed_bits;
 
     for (auto &bit_map: this->bits) {
         all_indexed_bits.push_back(bit_map.second);

--- a/cpm-hub/bits/BitsRepositoryInFilesystem.h
+++ b/cpm-hub/bits/BitsRepositoryInFilesystem.h
@@ -56,5 +56,9 @@ private:
 
     BitMetadata loadMetadata(const std::string& name, std::string bit_directory);
 
-    std::string latestVersionDirectory(std::string base_directory);
+    std::string latestVersionDirectory(const std::string& base_directory);
+
+    std::list<std::string> allVersionsForBit(const std::string &base_directory);
+
+    std::string bitBaseDirectory(const std::string& bit_name);
 };

--- a/tests/mocks/MockFilesystem.h
+++ b/tests/mocks/MockFilesystem.h
@@ -26,7 +26,10 @@
 class MockFilesystem: public Filesystem {
 public:
     void writeFile(std::string file_name, std::string contents) {
-        mock().actualCall("Filesystem.writeFile");
+        mock().actualCall("Filesystem.writeFile")
+              .withParameter("file_name", file_name.c_str())
+              .withParameter("contents", contents.c_str())
+              .returnStringValue();
     }
 
     std::string readFile(std::string file_name) {
@@ -36,7 +39,8 @@ public:
     }
 
     void createDirectory(std::string path) {
-        mock().actualCall("Filesystem.createDirectory");
+        mock().actualCall("Filesystem.createDirectory")
+              .withParameter("path", path.c_str());
     }
 
     std::list<std::string> listDirectories(std::string path) {

--- a/tests/mocks/cpputest.h
+++ b/tests/mocks/cpputest.h
@@ -17,10 +17,11 @@
  */
 #pragma once
 
+#define CPPUTEST_MEM_LEAK_DETECTION_DISABLED
+
 #include "CppUTest/CommandLineTestRunner.h"
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/MockSupport.h"
-
 
 #define ASSERT_TRUE(condition)                          CHECK(condition)
 #define ASSERT_FALSE(condition)                         CHECK_FALSE(condition)


### PR DESCRIPTION
This MR implements a method to retrieve all existing bits in the BitRepositoryInFilesystem. This is in preparation of the migration to SQL based storage.