### PR TITLE
Implemented migration code from old database type into sqlite database

### DIFF
--- a/cpm-hub/bits/BitsRepositoryInSqlite.h
+++ b/cpm-hub/bits/BitsRepositoryInSqlite.h
@@ -18,14 +18,14 @@
 #pragma once
 
 #include <bits/BitsRepository.h>
-#include <database/Sqlite3SqlDatabase.h>
+#include <database/SqlDatabaseSqlite3.h>
 
 #include <utility>
 
 
 class BitsRepositoryInSqlite: public BitsRepository {
 public:
-     BitsRepositoryInSqlite(std::string filename);
+     BitsRepositoryInSqlite(SqlDatabaseSqlite3 *database);
 
     void add(Bit &bit);
 
@@ -38,6 +38,12 @@ public:
     std::list<Bit> allBits();
 
 private:
-    Sqlite3SqlDatabase database;
+    SqlDatabaseSqlite3 *database;
+
+    void sanitizeDatabase();
+
+    void createBitsTable();
+
+    void sanitizeBitsTableColumns();
 };
 

--- a/cpm-hub/database/SqlDatabase.h
+++ b/cpm-hub/database/SqlDatabase.h
@@ -23,8 +23,8 @@
 #include <utility>
 
 struct SqlColumn {
-    std::string type;
     std::string name;
+    std::string type;
 };
 
 struct SqlField {
@@ -48,6 +48,8 @@ public:
     virtual void execute(std::string query) = 0;
 
     virtual void createTable(std::string query) = 0;
+
+    virtual bool hasColumn(std::string table, std::string column) = 0;
 
     virtual void insert(std::string query) = 0;
 

--- a/cpm-hub/database/SqlDatabaseSqlite3.h
+++ b/cpm-hub/database/SqlDatabaseSqlite3.h
@@ -21,15 +21,17 @@
 #include <database/SqlDatabase.h>
 
 
-class Sqlite3SqlDatabase: public SqlDatabase {
+class SqlDatabaseSqlite3: public SqlDatabase {
 public:
-    Sqlite3SqlDatabase(std::string file);
+    SqlDatabaseSqlite3(std::string file);
 
-    ~Sqlite3SqlDatabase();
+    ~SqlDatabaseSqlite3();
 
     virtual void execute(std::string query);
 
     virtual void createTable(std::string query);
+
+    virtual bool hasColumn(std::string table, std::string column);
 
     virtual void insert(std::string query);
 

--- a/cpm-hub/management/ProgramOptions.h
+++ b/cpm-hub/management/ProgramOptions.h
@@ -32,7 +32,14 @@ struct ProgramOptions {
         INFLUXDB,
     };
 
+    enum BitsRepositoryType {
+        BITS_REPOSITORY_FILESYSTEM,
+        BITS_REPOSITORY_SQLITE,
+    };
+
+    BitsRepositoryType bits_repository_type = BITS_REPOSITORY_FILESYSTEM;
     std::string bits_directory = ".";
+    std::string sqlite_database = "bits.db";
     AuthenticatorType authenticator_type = UNAUTHENTICATED;
     std::string access_file = ".access";
     std::string cpm_hub_url = "http://localhost:1234";

--- a/cpm-hub/management/program_options_parser.cpp
+++ b/cpm-hub/management/program_options_parser.cpp
@@ -33,6 +33,11 @@ map<string, ProgramOptions::KpiSinkType> string_to_kpi_sink = {
         {"influxdb", ProgramOptions::INFLUXDB},
 };
 
+map<string, ProgramOptions::BitsRepositoryType> string_to_bits_repository_type = {
+        {"filesystem", ProgramOptions::BITS_REPOSITORY_FILESYSTEM},
+        {"sqlite", ProgramOptions::BITS_REPOSITORY_SQLITE},
+};
+
 
 static ProgramOptions parseIniFile(string &ini_file)
 {
@@ -40,6 +45,8 @@ static ProgramOptions parseIniFile(string &ini_file)
     INIReader ini_reader(ini_file);
 
     program_options.bits_directory = ini_reader.Get("Service", "bits_directory", ".");
+    program_options.sqlite_database = ini_reader.Get("Service", "sqlite_database", "bits.db");
+    program_options.bits_repository_type = string_to_bits_repository_type[ini_reader.Get("Service", "bits_repository_type", "filesystem")];
     program_options.http_service_ip = ini_reader.Get("Service", "ip_bind", "127.0.0.1");
     program_options.http_service_port = ini_reader.GetInteger("Service", "port", 8000);
     program_options.authenticator_type = string_to_authenticator_type[ini_reader.Get("Service", "authentication", "unauthenticated")];

--- a/tests/unit/database/test_sqlite3_sql_database.cpp
+++ b/tests/unit/database/test_sqlite3_sql_database.cpp
@@ -15,35 +15,52 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include <cest/cest.h>
+#include <mocks/cpputest.h>
 
-#include <database/Sqlite3SqlDatabase.h>
+#include <database/SqlDatabaseSqlite3.h>
 
-using namespace cest;
 using namespace std;
 
 
-describe("Sqlite3 Database", []() {
-    it("finds a sqlite3 database row after insertion", []() {
-        list<SqlRow> selectResult;
-        Sqlite3SqlDatabase database(":memory:");
+TEST_GROUP(SqlDatabaseSqlite3) {
+};
 
-        database.createTable("CREATE TABLE users (name varchar(255), age int)");
-        database.insert("INSERT INTO users VALUES ('fulano', 18)");
-        selectResult = database.select("SELECT * FROM users");
 
-        expect(selectResult.size()).toBe(1);
-        expect(selectResult.front()["name"]).toBe("fulano");
-        expect(selectResult.front()["age"]).toBe("18");
-    });
+TEST_WITH_MOCK(SqlDatabaseSqlite3, finds_a_sqlite3_database_row_after_insertion)
+{
+    list<SqlRow> selectResult;
+    SqlDatabaseSqlite3 database(":memory:");
 
-    it("gets an empty list when select finds zero elements", []() {
-        list<SqlRow> selectResult;
-        Sqlite3SqlDatabase database(":memory:");
+    database.createTable("CREATE TABLE users (name varchar(255), age int)");
+    database.insert("INSERT INTO users VALUES ('fulano', 18)");
+    selectResult = database.select("SELECT * FROM users");
 
-        database.createTable("CREATE TABLE users (name varchar(255), age int)");
-        selectResult = database.select("SELECT * FROM users");
+    ASSERT_EQUAL(1, selectResult.size());
+    ASSERT_STRING("fulano", selectResult.front()["name"]);
+    ASSERT_STRING("18", selectResult.front()["age"]);
+}
 
-        expect(selectResult.size()).toBe(0);
-    });
-});
+
+TEST_WITH_MOCK(SqlDatabaseSqlite3, gets_an_empty_list_when_select_finds_zero_elements)
+{
+    list<SqlRow> selectResult;
+    SqlDatabaseSqlite3 database(":memory:");
+
+    database.createTable("CREATE TABLE users (name varchar(255), age int)");
+    selectResult = database.select("SELECT * FROM users");
+
+    ASSERT_EQUAL(0, selectResult.size());
+}
+
+
+TEST_WITH_MOCK(SqlDatabaseSqlite3, reports_when_a_table_column_exists)
+{
+    list<SqlRow> selectResult;
+    SqlDatabaseSqlite3 database(":memory:");
+
+    database.createTable("CREATE TABLE users (name varchar(255), age int)");
+
+    ASSERT_FALSE(database.hasColumn("usuarios", "columna"));
+    ASSERT_FALSE(database.hasColumn("users", "columna"));
+    ASSERT_TRUE(database.hasColumn("users", "name"));
+}


### PR DESCRIPTION
This MR improves the handling of the SQLite database from the `BitsRepositoryInSqlite`. It sanitizes the database tables and columns and includes a migration script that should be used just once and removed once the migration is completed. 